### PR TITLE
Centraliser la gestion des contrats + lien de signature tokenisé

### DIFF
--- a/index.html
+++ b/index.html
@@ -890,6 +890,7 @@ async function sendContractEmail(to, name, type, details) {
     terminated:  'Votre accès CoHabitat a été résilié',
     owner_activated:  'Contrat Modulimo activé — ' + details.building,
     owner_terminated: 'Contrat Modulimo résilié — ' + details.building,
+    signature_request: 'Signature requise — votre contrat ' + (details.building || ''),
   };
   const bodies = {
     activated: `
@@ -938,6 +939,18 @@ async function sendContractEmail(to, name, type, details) {
         <p style="color:#9a9890;font-size:14px;">Tous les accès résidents liés à cet immeuble ont également été résiliés. Contactez Modulimo pour plus d'information.</p>
         <p style="margin-top:24px;font-size:12px;color:#5a5856;">Modulimo Central</p>
       </div>`,
+    signature_request: `
+      <div style="font-family:Arial,sans-serif;max-width:560px;margin:0 auto;background:#0f0f0f;color:#e8e6df;padding:32px;border-radius:12px;">
+        <h2 style="color:#c8a96e;margin:0 0 16px;">📄 Signature de contrat requise</h2>
+        <p>Bonjour <strong>${name}</strong>,</p>
+        <p>Votre contrat ${details.contractType === 'owner' ? 'de propriétaire' : 'de résident'} pour <strong>${details.building || '—'}</strong> est prêt à être signé.</p>
+        <p style="color:#9a9890;font-size:14px;">Cliquez sur le lien ci-dessous pour consulter les termes et apposer votre signature électronique. Ce lien est personnel, sécurisé et valide ${details.expiresDays || 14} jours.</p>
+        <p style="text-align:center;margin:28px 0;">
+          <a href="${details.url}" style="display:inline-block;background:#c8a96e;color:#0f0f0f;padding:14px 32px;border-radius:8px;text-decoration:none;font-weight:700;">✍ Signer le contrat</a>
+        </p>
+        <p style="font-size:12px;color:#9a9890;word-break:break-all;">Si le bouton ne fonctionne pas, copiez ce lien : ${details.url}</p>
+        <p style="margin-top:24px;font-size:12px;color:#5a5856;">Modulimo — ce lien à usage unique expirera automatiquement après signature.</p>
+      </div>`,
   };
 
   try {
@@ -957,6 +970,72 @@ async function sendContractEmail(to, name, type, details) {
     console.log('[email] Envoyé à', to, '— type:', type);
   } catch(e) {
     console.warn('[email] Erreur envoi:', e.message);
+  }
+}
+
+// ── SIGNATURE LINK ───────────────────────────────────────────────────────────
+// Base URL de la page publique de signature. Doit pointer vers sign.html
+// hébergé dans le repo cohabitat (servi sur chaque domaine d'immeuble, ou
+// le domaine canonique ci-dessous).
+const SIGN_BASE_URL     = 'https://cohabitat.modulimo.com/sign.html';
+const SIGN_EXPIRY_DAYS  = 14;
+
+function _generateSignatureToken() {
+  // 32 octets aléatoires → base64url (~43 chars). Assez d'entropie pour un lien public.
+  const buf = new Uint8Array(32);
+  crypto.getRandomValues(buf);
+  let b64 = btoa(String.fromCharCode.apply(null, buf));
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+// Génère un lien tokenisé et l'envoie par email au signataire du contrat.
+// Utilisable pour contrats 'resident' ET 'owner'.
+async function sendSignatureLink(contractId, btn) {
+  if(btn) { btn.disabled = true; btn.textContent = '…'; }
+  try {
+    const { data: c, error: e1 } = await sb.from('contracts')
+      .select('id, type, plan, client_id, owner_client_id, signed_at')
+      .eq('id', contractId).single();
+    if(e1 || !c) throw new Error(e1?.message || 'Contrat introuvable');
+    if(c.signed_at) { toast('Ce contrat est déjà signé', 'error'); return; }
+
+    const { data: signer } = await sb.from('clients')
+      .select('name, contact_email, contact_name')
+      .eq('id', c.client_id).single();
+    if(!signer?.contact_email) { toast('Aucun courriel pour ce client', 'error'); return; }
+
+    let buildingName = '';
+    if(c.owner_client_id) {
+      const { data: own } = await sb.from('clients').select('name').eq('id', c.owner_client_id).single();
+      buildingName = own?.name || '';
+    } else if(c.type === 'owner') {
+      buildingName = signer.name || '';
+    }
+
+    const token   = _generateSignatureToken();
+    const expires = new Date(Date.now() + SIGN_EXPIRY_DAYS * 86400000).toISOString();
+
+    const { error: e2 } = await sb.from('contracts').update({
+      signature_token:            token,
+      signature_token_expires_at: expires
+    }).eq('id', contractId);
+    if(e2) throw new Error('Erreur token: ' + e2.message);
+
+    const url = SIGN_BASE_URL + '?token=' + encodeURIComponent(token);
+
+    await sendContractEmail(
+      signer.contact_email,
+      signer.contact_name || signer.name || 'Client',
+      'signature_request',
+      { url, building: buildingName, contractType: c.type, expiresDays: SIGN_EXPIRY_DAYS }
+    );
+
+    toast('✍ Lien de signature envoyé à ' + signer.contact_email, 'success');
+  } catch(e) {
+    console.error('[sendSignatureLink]', e);
+    toast('Erreur: ' + e.message, 'error');
+  } finally {
+    if(btn) { btn.disabled = false; btn.textContent = '✍ Lien signature'; }
   }
 }
 
@@ -1184,6 +1263,7 @@ async function loadContracts() {
         ${group.ownerContract
           ? `<span class="badge ${statusColors[group.ownerContract.status] || 'badge-gray'}" style="margin-left:10px;font-size:10px;">Contrat proprio: ${statusLabels[group.ownerContract.status] || group.ownerContract.status}</span>
              <span style="font-size:11px;color:var(--text3);margin-left:8px;">${group.ownerContract.starts_at || ''} → ${group.ownerContract.ends_at || '∞'}</span>
+             ${!group.ownerContract.signed_at ? `<button class="btn btn-info btn-sm" style="margin-left:8px;font-size:10px;" onclick="sendSignatureLink('${group.ownerContract.id}', this)">✍ Lien signature</button>` : `<span class="badge badge-green" style="margin-left:8px;font-size:10px;" title="Signé le ${new Date(group.ownerContract.signed_at).toLocaleDateString('fr-CA')} par ${group.ownerContract.signed_by_name||''}">✓ Signé</span>`}
              <button class="btn btn-danger btn-sm" style="margin-left:8px;font-size:10px;" onclick="terminateContract('${group.ownerContract.id}')">Résilier</button>`
           : `<button class="btn btn-primary btn-sm" style="margin-left:10px;font-size:10px;" onclick="openContractForClient('${ownId}', 'owner')">+ Contrat proprio</button>`}
       </td>
@@ -1213,6 +1293,7 @@ async function loadContracts() {
         <td>${paidBadge}</td>
         <td><div class="td-actions">
           <button class="btn btn-info btn-sm" onclick="showClientContracts('${c.client_id}', '${resName.replace(/'/g, "\'")}', 'resident')">📄 Contrat</button>
+          ${!c.signed_at && c.status !== 'terminated' ? `<button class="btn btn-info btn-sm" onclick="sendSignatureLink('${c.id}', this)">✍ Lien signature</button>` : ''}
           <button class="btn btn-success btn-sm" onclick="renewPayment('${c.id}')">💳 +1 mois</button>
           ${canSuspend && paidLate ? `<button class="btn btn-warning btn-sm" onclick="suspendForNonPayment('${c.id}')">🔒 Suspendre</button>` : ''}
           ${canReactivate ? `<button class="btn btn-warning btn-sm" onclick="suspendForNonPayment('${c.id}')">🔒 Suspendre</button>` : ''}
@@ -1241,6 +1322,7 @@ async function loadContracts() {
         <td>${signedBadge}</td>
         <td><div class="td-actions">
           <button class="btn btn-info btn-sm" onclick="showClientContracts('${c.client_id}', '${(resClient.contact_name || resClient.name || '').replace(/'/g, "\\'")}', 'resident')">📄 Contrat</button>
+          ${!c.signed_at && c.status !== 'terminated' ? `<button class="btn btn-info btn-sm" onclick="sendSignatureLink('${c.id}', this)">✍ Lien signature</button>` : ''}
           <button class="btn btn-secondary btn-sm" onclick="editContract('${c.id}')">Modifier</button>
           ${c.status === 'active' ? `<button class="btn btn-warning btn-sm" onclick="suspendContract('${c.id}')">⏸ Suspendre</button>` : ''}
           ${c.status === 'suspended' ? `<button class="btn btn-success btn-sm" onclick="reactivateContract('${c.id}')">▶ Réactiver</button>` : ''}
@@ -1730,6 +1812,7 @@ async function ccmLoadContracts(clientId, clientName, clientType) {
         <td style="padding:10px;"><span class="badge ${statusColors[c.status]||'badge-gray'}">${statusLabels[c.status]||c.status}</span></td>
         <td style="padding:10px;">${signedBadge}</td>
         <td style="padding:10px;"><div class="td-actions">
+          ${!c.signed_at && c.status !== 'terminated' ? `<button class="btn btn-info btn-sm" title="Envoyer lien de signature" onclick="sendSignatureLink('${c.id}', this)">✍</button>` : ''}
           ${canSuspend    ? `<button class="btn btn-warning btn-sm" title="Suspendre" onclick="suspendContract('${c.id}').then(()=>ccmLoadContracts('${clientId}','${clientName}','${clientType}'))">⏸</button>` : ''}
           ${canReactivate ? `<button class="btn btn-success btn-sm" title="Réactiver" onclick="reactivateContract('${c.id}').then(()=>ccmLoadContracts('${clientId}','${clientName}','${clientType}'))">▶</button>` : ''}
           ${canTerminate  ? `<button class="btn btn-danger btn-sm" title="Résilier" onclick="terminateContract('${c.id}').then(()=>ccmLoadContracts('${clientId}','${clientName}','${clientType}'))">✕</button>` : ''}

--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
       <div class="nav-item active" onclick="nav('dashboard')">📊 Tableau de bord</div>
       <div class="nav-item" onclick="nav('clients')">🏢 Clients</div>
       <div class="nav-item" onclick="nav('contracts')">📄 Contrats</div>
+      <div class="nav-item" onclick="nav('invoices')">🧾 Factures</div>
       <div class="nav-item" onclick="nav('licences')">🗝 Licences</div>
       <div class="nav-item" onclick="nav('networks')">🔗 Réseaux</div>
       <div class="nav-item" onclick="nav('plans')">📦 Forfaits</div>
@@ -189,6 +190,50 @@
             </thead>
             <tbody id="contracts-tbody">
               <tr><td colspan="8" style="text-align:center;color:var(--text3)">Chargement…</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- FACTURES -->
+      <div id="page-invoices" class="page">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;gap:10px;flex-wrap:wrap;">
+          <div class="page-title" style="margin:0">Factures</div>
+          <div style="display:flex;gap:8px;align-items:center;">
+            <select id="inv-filter-status" onchange="loadInvoices()" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);padding:6px 10px;border-radius:6px;font-size:13px;">
+              <option value="">Toutes</option>
+              <option value="issued" selected>À encaisser</option>
+              <option value="paid">Payées</option>
+              <option value="overdue">En retard</option>
+              <option value="cancelled">Annulées</option>
+            </select>
+            <select id="inv-filter-mode" onchange="loadInvoices()" style="background:var(--surface2);border:1px solid var(--border);color:var(--text);padding:6px 10px;border-radius:6px;font-size:13px;">
+              <option value="">Tous modes</option>
+              <option value="owner_collects">Proprio collecte</option>
+              <option value="modulimo_collects">Modulimo collecte</option>
+            </select>
+            <button class="btn btn-secondary btn-sm" onclick="loadInvoices()">↻</button>
+          </div>
+        </div>
+        <div class="card" style="padding:0">
+          <table>
+            <thead>
+              <tr>
+                <th>Résident</th>
+                <th>Immeuble</th>
+                <th>Période</th>
+                <th>Frais mensuel</th>
+                <th>Services</th>
+                <th>Total</th>
+                <th>Commission</th>
+                <th>Net proprio</th>
+                <th>Mode</th>
+                <th>Statut</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody id="invoices-tbody">
+              <tr><td colspan="11" style="text-align:center;color:var(--text3)">Chargement…</td></tr>
             </tbody>
           </table>
         </div>
@@ -765,6 +810,7 @@ function nav(page) {
   if (page === 'dashboard') loadDashboard();
   if (page === 'clients')   loadClients();
   if (page === 'contracts') loadContracts();
+  if (page === 'invoices')  loadInvoices();
   if (page === 'licences')  loadLicences();
   if (page === 'networks')  loadNetworks();
   if (page === 'plans')     loadPlans();
@@ -871,12 +917,17 @@ async function loadClients() {
 
 let RESEND_KEY = '';
 const RESEND_FROM = 'Modulimo <no-reply@modulimo.com>';
+let MODULIMO_COMMISSION_PCT = 5;
 
 async function loadAppConfig() {
   try {
     const { data } = await sb.from('app_config').select('key, value');
     (data || []).forEach(row => {
       if(row.key === 'resend_key') RESEND_KEY = row.value;
+      if(row.key === 'modulimo_commission_pct') {
+        const n = parseFloat(row.value);
+        if(!isNaN(n)) MODULIMO_COMMISSION_PCT = n;
+      }
     });
   } catch(e) {
     console.warn('[config] Erreur chargement config:', e.message);
@@ -1037,6 +1088,366 @@ async function sendSignatureLink(contractId, btn) {
   } finally {
     if(btn) { btn.disabled = false; btn.textContent = '✍ Lien signature'; }
   }
+}
+
+// ── FACTURATION (cash / manuel, sans Stripe) ────────────────────────────────
+// Règle : une facture par résident par mois, ventilée en ligne de frais mensuel
+// + une ligne par service consommé (puisée dans la DB tenant de l'immeuble).
+// L'encaissement est confirmé par l'admin ou le proprio selon contracts.billing_mode.
+
+function _firstOfLastMonth() {
+  const d = new Date(); d.setDate(1); d.setMonth(d.getMonth() - 1);
+  return d.toISOString().slice(0, 10);
+}
+function _firstOfThisMonth() {
+  const d = new Date(); d.setDate(1);
+  return d.toISOString().slice(0, 10);
+}
+function _fmtMoney(n) {
+  return (Number(n) || 0).toFixed(2) + ' $';
+}
+
+// Mappe un type de transaction tenant → catégorie de ligne de facture
+function _categoryForTxType(txType) {
+  switch(txType) {
+    case 'space_reservation':   return 'space_reservation';
+    case 'trip_booking':        return 'trip';
+    case 'trip_cancel_charge':  return 'trip_charge';
+    case 'trip_driver_charge':  return 'trip_charge';
+    default:                    return 'other';
+  }
+}
+
+// Ouvre le modal de génération de facture pour un contrat
+function openGenerateInvoiceModal(contractId) {
+  const pStart = _firstOfLastMonth();
+  const pEnd   = _firstOfThisMonth();
+  // Modal inline minimal
+  const html = `
+    <div id="modal-genfact-overlay" style="position:fixed;inset:0;background:rgba(0,0,0,.55);z-index:10000;display:flex;align-items:center;justify-content:center;padding:20px;" onclick="if(event.target===this)closeGenInvoiceModal()">
+      <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;max-width:440px;width:100%;padding:24px;">
+        <h3 style="margin:0 0 14px;font-size:1.05rem;">🧾 Générer une facture</h3>
+        <p style="margin:0 0 14px;font-size:13px;color:var(--text3);">La facture agrégera le frais mensuel du contrat et chaque service consommé par le résident sur la période (réservations, trajets, etc.).</p>
+        <label style="display:block;font-size:12px;color:var(--text3);margin-bottom:4px;">Période début</label>
+        <input id="gen-period-start" type="date" value="${pStart}" style="width:100%;padding:8px 10px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;margin-bottom:10px;">
+        <label style="display:block;font-size:12px;color:var(--text3);margin-bottom:4px;">Période fin (exclue)</label>
+        <input id="gen-period-end" type="date" value="${pEnd}" style="width:100%;padding:8px 10px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;margin-bottom:14px;">
+        <div id="gen-invoice-status" style="font-size:12px;color:var(--text3);margin-bottom:10px;min-height:18px;"></div>
+        <div style="display:flex;gap:10px;">
+          <button class="btn btn-secondary" style="flex:1;" onclick="closeGenInvoiceModal()">Annuler</button>
+          <button id="gen-invoice-btn" class="btn btn-primary" style="flex:2;" onclick="generateInvoice('${contractId}')">Générer</button>
+        </div>
+      </div>
+    </div>`;
+  const wrap = document.createElement('div');
+  wrap.innerHTML = html;
+  document.body.appendChild(wrap.firstElementChild);
+}
+function closeGenInvoiceModal() {
+  const el = document.getElementById('modal-genfact-overlay');
+  if(el) el.remove();
+}
+
+// Récupère les transactions depuis la DB tenant d'un immeuble via sa licence
+async function _fetchTenantTransactions(ownerClientId, cohabitatUserId, periodStart, periodEnd) {
+  const { data: lics } = await sb.from('licences')
+    .select('supabase_url, anon_key')
+    .eq('client_id', ownerClientId).eq('active', true).limit(1);
+  const lic = lics?.[0];
+  if(!lic?.supabase_url) throw new Error('Licence immeuble introuvable');
+  const key = lic.anon_key || CENTRAL_KEY;
+  const url = lic.supabase_url + '/rest/v1/transactions'
+    + '?user_id=eq.' + encodeURIComponent(cohabitatUserId)
+    + '&is_demo=eq.false'
+    + '&amount=lt.0'
+    + '&created_at=gte.' + encodeURIComponent(periodStart)
+    + '&created_at=lt.'  + encodeURIComponent(periodEnd)
+    + '&select=id,amount,type,description,created_at,reference_type'
+    + '&order=created_at.asc';
+  const res = await fetch(url, { headers: { apikey: key, Authorization: 'Bearer ' + key } });
+  if(!res.ok) throw new Error('Erreur DB tenant: HTTP ' + res.status);
+  return await res.json();
+}
+
+async function generateInvoice(contractId) {
+  const btn = document.getElementById('gen-invoice-btn');
+  const status = document.getElementById('gen-invoice-status');
+  const ps = document.getElementById('gen-period-start').value;
+  const pe = document.getElementById('gen-period-end').value;
+  if(!ps || !pe || ps >= pe) { status.textContent = 'Période invalide'; return; }
+
+  if(btn) { btn.disabled = true; btn.textContent = 'Génération…'; }
+  if(status) status.textContent = 'Lecture du contrat…';
+
+  try {
+    const { data: c, error: ce } = await sb.from('contracts')
+      .select('id, client_id, owner_client_id, plan, monthly_amount, billing_mode, type')
+      .eq('id', contractId).single();
+    if(ce || !c) throw new Error(ce?.message || 'Contrat introuvable');
+
+    const { data: cli } = await sb.from('clients')
+      .select('id, cohabitat_user_id, name, contact_email, contact_name')
+      .eq('id', c.client_id).single();
+    if(!cli) throw new Error('Client introuvable');
+
+    // Frais mensuel : override contrat > défaut plan
+    let monthlyFee = Number(c.monthly_amount) || 0;
+    if(!monthlyFee && c.plan) {
+      const { data: plan } = await sb.from('plans').select('price_monthly').eq('code', c.plan).maybeSingle();
+      if(plan?.price_monthly) monthlyFee = Number(plan.price_monthly) || 0;
+    }
+
+    const billingMode = c.billing_mode || 'owner_collects';
+
+    // Transactions tenant (services consommés)
+    let tenantTx = [];
+    if(c.owner_client_id && cli.cohabitat_user_id) {
+      if(status) status.textContent = 'Lecture des services consommés…';
+      try {
+        tenantTx = await _fetchTenantTransactions(c.owner_client_id, cli.cohabitat_user_id, ps, pe);
+      } catch(e) {
+        console.warn('[invoice] tenant tx failed:', e.message);
+        if(status) status.textContent = '⚠ Transactions tenant indisponibles, facture avec frais mensuel seul';
+      }
+    }
+
+    // Ligne frais mensuel + lignes services
+    const lines = [];
+    if(monthlyFee > 0) {
+      const label = c.plan === 'network' ? 'Forfait Réseau' : (c.plan === 'owner' ? 'Licence propriétaire' : 'Forfait Local');
+      lines.push({
+        category: 'monthly_fee',
+        description: label + ' — ' + ps + ' → ' + pe,
+        quantity: 1, unit_amount: monthlyFee, total_amount: monthlyFee,
+        transaction_date: null
+      });
+    }
+    let servicesSubtotal = 0;
+    tenantTx.forEach(t => {
+      const amt = Math.abs(Number(t.amount) || 0);
+      if(amt <= 0) return;
+      servicesSubtotal += amt;
+      lines.push({
+        category: _categoryForTxType(t.type),
+        description: (t.description || t.type || 'Service'),
+        quantity: 1, unit_amount: amt, total_amount: amt,
+        transaction_ref: t.id,
+        transaction_date: t.created_at
+      });
+    });
+
+    const total       = Math.round((monthlyFee + servicesSubtotal) * 100) / 100;
+    const commissionP = Number(MODULIMO_COMMISSION_PCT) || 0;
+    const commission  = Math.round(total * commissionP) / 100;
+    const netOwner    = Math.round((total - commission) * 100) / 100;
+
+    if(status) status.textContent = 'Écriture de la facture…';
+    const { data: inv, error: ie } = await sb.from('invoices').insert({
+      contract_id:        c.id,
+      client_id:          c.client_id,
+      owner_client_id:    c.owner_client_id,
+      period_start:       ps,
+      period_end:         pe,
+      monthly_fee:        monthlyFee,
+      services_subtotal:  servicesSubtotal,
+      total_amount:       total,
+      commission_pct:     commissionP,
+      commission_amount:  commission,
+      net_to_owner:       netOwner,
+      billing_mode:       billingMode,
+      status:             'issued'
+    }).select('id').single();
+    if(ie) throw new Error('Erreur facture: ' + ie.message);
+
+    if(lines.length) {
+      const rows = lines.map(l => Object.assign({ invoice_id: inv.id }, l));
+      const { error: le } = await sb.from('invoice_line_items').insert(rows);
+      if(le) console.warn('[invoice] line_items insert:', le.message);
+    }
+
+    closeGenInvoiceModal();
+    toast('🧾 Facture générée : ' + _fmtMoney(total) + ' (' + lines.length + ' ligne' + (lines.length>1?'s':'') + ')', 'success');
+    if(typeof loadContracts === 'function') loadContracts();
+  } catch(e) {
+    console.error('[generateInvoice]', e);
+    if(status) status.textContent = 'Erreur: ' + e.message;
+    if(btn) { btn.disabled = false; btn.textContent = 'Générer'; }
+  }
+}
+
+// Enregistre un paiement manuel (cash/virement/chèque) sur une facture
+function openRecordPaymentModal(invoiceId, totalAmount, billingMode) {
+  const defaultPaidBy = billingMode === 'modulimo_collects' ? 'Modulimo admin' : 'Propriétaire';
+  const html = `
+    <div id="modal-rp-overlay" style="position:fixed;inset:0;background:rgba(0,0,0,.55);z-index:10000;display:flex;align-items:center;justify-content:center;padding:20px;" onclick="if(event.target===this)closeRecordPaymentModal()">
+      <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;max-width:440px;width:100%;padding:24px;">
+        <h3 style="margin:0 0 14px;font-size:1.05rem;">💵 Enregistrer un paiement</h3>
+        <p style="margin:0 0 14px;font-size:13px;color:var(--text3);">Montant facturé : <strong>${_fmtMoney(totalAmount)}</strong> — mode : ${billingMode === 'modulimo_collects' ? 'Modulimo collecte' : 'Propriétaire collecte'}</p>
+        <label style="display:block;font-size:12px;color:var(--text3);margin-bottom:4px;">Méthode</label>
+        <select id="rp-method" style="width:100%;padding:8px 10px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;margin-bottom:10px;">
+          <option value="cash">Cash</option>
+          <option value="etransfer">Virement Interac</option>
+          <option value="check">Chèque</option>
+          <option value="card">Carte</option>
+          <option value="other">Autre</option>
+        </select>
+        <label style="display:block;font-size:12px;color:var(--text3);margin-bottom:4px;">Reçu par</label>
+        <input id="rp-paid-by" type="text" value="${defaultPaidBy}" style="width:100%;padding:8px 10px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;margin-bottom:10px;">
+        <label style="display:block;font-size:12px;color:var(--text3);margin-bottom:4px;">Notes (optionnel)</label>
+        <textarea id="rp-notes" rows="2" style="width:100%;padding:8px 10px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;margin-bottom:14px;resize:vertical;"></textarea>
+        <div id="rp-status" style="font-size:12px;color:var(--text3);margin-bottom:10px;min-height:18px;"></div>
+        <div style="display:flex;gap:10px;">
+          <button class="btn btn-secondary" style="flex:1;" onclick="closeRecordPaymentModal()">Annuler</button>
+          <button id="rp-btn" class="btn btn-primary" style="flex:2;" onclick="submitRecordPayment('${invoiceId}')">Confirmer encaissement</button>
+        </div>
+      </div>
+    </div>`;
+  const wrap = document.createElement('div');
+  wrap.innerHTML = html;
+  document.body.appendChild(wrap.firstElementChild);
+}
+function closeRecordPaymentModal() {
+  const el = document.getElementById('modal-rp-overlay');
+  if(el) el.remove();
+}
+async function submitRecordPayment(invoiceId) {
+  const btn = document.getElementById('rp-btn');
+  const status = document.getElementById('rp-status');
+  const method = document.getElementById('rp-method').value;
+  const paidBy = document.getElementById('rp-paid-by').value.trim();
+  const notes  = document.getElementById('rp-notes').value.trim();
+  if(!paidBy) { status.textContent = 'Préciser qui a reçu le paiement'; return; }
+  if(btn) { btn.disabled = true; btn.textContent = 'Enregistrement…'; }
+  try {
+    const { data, error } = await sb.rpc('record_invoice_payment', {
+      p_invoice_id: invoiceId, p_method: method, p_paid_by: paidBy, p_notes: notes || null
+    });
+    if(error) throw new Error(error.message);
+    closeRecordPaymentModal();
+    toast('✓ Paiement enregistré', 'success');
+    if(typeof loadInvoices === 'function') loadInvoices();
+    if(typeof loadContracts === 'function') loadContracts();
+  } catch(e) {
+    console.error('[submitRecordPayment]', e);
+    if(status) status.textContent = 'Erreur: ' + e.message;
+    if(btn) { btn.disabled = false; btn.textContent = 'Confirmer encaissement'; }
+  }
+}
+
+// Approuver / refuser une demande d'upgrade de plan (Local → Réseau)
+async function approvePlanUpgrade(contractId) {
+  if(!confirm('Approuver la demande d\'upgrade vers le forfait demandé ?')) return;
+  const { data: c } = await sb.from('contracts')
+    .select('upgrade_requested_to_plan').eq('id', contractId).single();
+  if(!c?.upgrade_requested_to_plan) { toast('Aucune demande en attente', 'error'); return; }
+  const { error } = await sb.from('contracts').update({
+    plan: c.upgrade_requested_to_plan,
+    upgrade_requested_to_plan: null,
+    upgrade_requested_at: null
+  }).eq('id', contractId);
+  if(error) { toast('Erreur: ' + error.message, 'error'); return; }
+  toast('✓ Forfait mis à jour vers ' + c.upgrade_requested_to_plan, 'success');
+  if(typeof loadContracts === 'function') loadContracts();
+}
+async function rejectPlanUpgrade(contractId) {
+  if(!confirm('Refuser la demande d\'upgrade ?')) return;
+  const { error } = await sb.from('contracts').update({
+    upgrade_requested_to_plan: null, upgrade_requested_at: null
+  }).eq('id', contractId);
+  if(error) { toast('Erreur: ' + error.message, 'error'); return; }
+  toast('Demande refusée', 'success');
+  if(typeof loadContracts === 'function') loadContracts();
+}
+
+// Charge et affiche la liste des factures (toutes ou filtrées)
+async function loadInvoices() {
+  const tbody = document.getElementById('invoices-tbody');
+  if(!tbody) return;
+  tbody.innerHTML = '<tr><td colspan="11" style="text-align:center;color:var(--text3)">Chargement…</td></tr>';
+
+  const statusFilter = document.getElementById('inv-filter-status')?.value || '';
+  const modeFilter   = document.getElementById('inv-filter-mode')?.value || '';
+
+  let q = sb.from('invoices').select(
+    'id, client_id, owner_client_id, period_start, period_end, issued_at, ' +
+    'monthly_fee, services_subtotal, total_amount, commission_pct, commission_amount, ' +
+    'net_to_owner, billing_mode, status, paid_at, paid_method'
+  ).order('issued_at', { ascending: false });
+  if(statusFilter) q = q.eq('status', statusFilter);
+  if(modeFilter)   q = q.eq('billing_mode', modeFilter);
+
+  const { data: invs, error } = await q;
+  if(error) { tbody.innerHTML = '<tr><td colspan="11" style="text-align:center;color:var(--accent3)">Erreur: ' + error.message + '</td></tr>'; return; }
+  if(!invs || !invs.length) { tbody.innerHTML = '<tr><td colspan="11" style="text-align:center;color:var(--text3)">Aucune facture</td></tr>'; return; }
+
+  const ids = [...new Set([...invs.map(i=>i.client_id), ...invs.map(i=>i.owner_client_id)].filter(Boolean))];
+  const { data: clis } = await sb.from('clients').select('id, name, contact_name').in('id', ids);
+  const m = {}; (clis||[]).forEach(c => { m[c.id] = c; });
+
+  const statusColors = { issued:'badge-yellow', paid:'badge-green', overdue:'badge-red', cancelled:'badge-gray', draft:'badge-gray' };
+  const statusLabels = { issued:'À encaisser', paid:'Payée', overdue:'En retard', cancelled:'Annulée', draft:'Brouillon' };
+  const modeLabels   = { owner_collects:'🏢 Proprio', modulimo_collects:'🟠 Modulimo' };
+
+  tbody.innerHTML = invs.map(i => {
+    const cli = m[i.client_id] || {};
+    const own = m[i.owner_client_id] || {};
+    const resName = cli.contact_name || cli.name || '—';
+    return `<tr>
+      <td><strong>${resName}</strong></td>
+      <td style="font-size:12px;color:var(--text3)">${own.name || '—'}</td>
+      <td style="font-size:12px;">${i.period_start} → ${i.period_end}</td>
+      <td style="text-align:right;font-size:12px;">${_fmtMoney(i.monthly_fee)}</td>
+      <td style="text-align:right;font-size:12px;">${_fmtMoney(i.services_subtotal)}</td>
+      <td style="text-align:right;font-weight:700;">${_fmtMoney(i.total_amount)}</td>
+      <td style="text-align:right;font-size:11px;color:var(--text3);">${_fmtMoney(i.commission_amount)} (${i.commission_pct}%)</td>
+      <td style="text-align:right;font-size:12px;">${_fmtMoney(i.net_to_owner)}</td>
+      <td style="font-size:11px;">${modeLabels[i.billing_mode] || i.billing_mode}</td>
+      <td><span class="badge ${statusColors[i.status] || 'badge-gray'}">${statusLabels[i.status] || i.status}</span>${i.paid_at ? '<br><span style="font-size:10px;color:var(--text3);">' + new Date(i.paid_at).toLocaleDateString('fr-CA') + '</span>' : ''}</td>
+      <td><div class="td-actions">
+        <button class="btn btn-info btn-sm" onclick="viewInvoiceDetail('${i.id}')">👁</button>
+        ${i.status !== 'paid' && i.status !== 'cancelled' ? `<button class="btn btn-success btn-sm" onclick="openRecordPaymentModal('${i.id}', ${i.total_amount}, '${i.billing_mode}')">💵 Encaisser</button>` : ''}
+      </div></td>
+    </tr>`;
+  }).join('');
+}
+
+// Affiche le détail d'une facture (lignes)
+async function viewInvoiceDetail(invoiceId) {
+  const { data: inv } = await sb.from('invoices').select('*').eq('id', invoiceId).single();
+  if(!inv) { toast('Facture introuvable', 'error'); return; }
+  const { data: lines } = await sb.from('invoice_line_items').select('*').eq('invoice_id', invoiceId).order('transaction_date', { nullsFirst: true });
+  const catLbl = { monthly_fee:'Frais mensuel', space_reservation:'🏢 Espace', trip:'🚗 Trajet', trip_charge:'🚗 Frais', lunch:'🍱 Lunch', other:'•' };
+  const rows = (lines || []).map(l => `
+    <tr>
+      <td style="padding:8px;font-size:12px;">${catLbl[l.category] || l.category}</td>
+      <td style="padding:8px;font-size:12px;">${(l.description||'').replace(/</g,'&lt;')}</td>
+      <td style="padding:8px;font-size:11px;color:var(--text3);">${l.transaction_date ? new Date(l.transaction_date).toLocaleDateString('fr-CA') : '—'}</td>
+      <td style="padding:8px;text-align:right;font-size:12px;">${_fmtMoney(l.total_amount)}</td>
+    </tr>`).join('') || '<tr><td colspan="4" style="padding:16px;text-align:center;color:var(--text3);font-style:italic;">Aucune ligne</td></tr>';
+  const html = `
+    <div id="modal-inv-overlay" style="position:fixed;inset:0;background:rgba(0,0,0,.55);z-index:10000;display:flex;align-items:center;justify-content:center;padding:20px;" onclick="if(event.target===this)this.remove()">
+      <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;max-width:640px;width:100%;max-height:90vh;overflow:auto;">
+        <div style="padding:20px;border-bottom:1px solid var(--border);display:flex;align-items:center;justify-content:space-between;">
+          <h3 style="margin:0;font-size:1.05rem;">🧾 Facture ${inv.period_start} → ${inv.period_end}</h3>
+          <button class="btn btn-secondary btn-sm" onclick="document.getElementById('modal-inv-overlay').remove()">✕</button>
+        </div>
+        <div style="padding:20px;">
+          <table style="width:100%;border-collapse:collapse;border:1px solid var(--border);border-radius:8px;overflow:hidden;">
+            <thead><tr style="background:var(--surface2);font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:var(--text3);"><th style="padding:8px;text-align:left;">Cat.</th><th style="padding:8px;text-align:left;">Description</th><th style="padding:8px;text-align:left;">Date</th><th style="padding:8px;text-align:right;">Montant</th></tr></thead>
+            <tbody>${rows}</tbody>
+          </table>
+          <div style="margin-top:16px;padding-top:16px;border-top:1px solid var(--border);font-size:13px;">
+            <div style="display:flex;justify-content:space-between;margin-bottom:4px;"><span style="color:var(--text3);">Frais mensuel</span><span>${_fmtMoney(inv.monthly_fee)}</span></div>
+            <div style="display:flex;justify-content:space-between;margin-bottom:4px;"><span style="color:var(--text3);">Services consommés</span><span>${_fmtMoney(inv.services_subtotal)}</span></div>
+            <div style="display:flex;justify-content:space-between;margin-bottom:4px;font-weight:700;"><span>Total</span><span>${_fmtMoney(inv.total_amount)}</span></div>
+            <div style="display:flex;justify-content:space-between;margin-bottom:4px;font-size:12px;color:var(--text3);"><span>Commission Modulimo (${inv.commission_pct}%)</span><span>${_fmtMoney(inv.commission_amount)}</span></div>
+            <div style="display:flex;justify-content:space-between;font-size:12px;color:var(--accent);"><span>Net propriétaire</span><span>${_fmtMoney(inv.net_to_owner)}</span></div>
+          </div>
+        </div>
+      </div>
+    </div>`;
+  const w = document.createElement('div'); w.innerHTML = html;
+  document.body.appendChild(w.firstElementChild);
 }
 
 async function loadPendingRequests() {
@@ -1215,7 +1626,7 @@ async function loadContracts() {
   tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;color:var(--text3)">Chargement…</td></tr>';
 
   const { data, error } = await sb.from('contracts')
-    .select('id, type, plan, status, starts_at, ends_at, paid_until, client_id, owner_client_id, created_at, signed_at, signed_by_name')
+    .select('id, type, plan, status, starts_at, ends_at, paid_until, client_id, owner_client_id, created_at, signed_at, signed_by_name, upgrade_requested_to_plan, upgrade_requested_at, monthly_amount, billing_mode')
     .order('owner_client_id', { ascending: true })
     .order('created_at', { ascending: false });
 
@@ -1264,6 +1675,7 @@ async function loadContracts() {
           ? `<span class="badge ${statusColors[group.ownerContract.status] || 'badge-gray'}" style="margin-left:10px;font-size:10px;">Contrat proprio: ${statusLabels[group.ownerContract.status] || group.ownerContract.status}</span>
              <span style="font-size:11px;color:var(--text3);margin-left:8px;">${group.ownerContract.starts_at || ''} → ${group.ownerContract.ends_at || '∞'}</span>
              ${!group.ownerContract.signed_at ? `<button class="btn btn-info btn-sm" style="margin-left:8px;font-size:10px;" onclick="sendSignatureLink('${group.ownerContract.id}', this)">✍ Lien signature</button>` : `<span class="badge badge-green" style="margin-left:8px;font-size:10px;" title="Signé le ${new Date(group.ownerContract.signed_at).toLocaleDateString('fr-CA')} par ${group.ownerContract.signed_by_name||''}">✓ Signé</span>`}
+             <button class="btn btn-primary btn-sm" style="margin-left:8px;font-size:10px;" onclick="openGenerateInvoiceModal('${group.ownerContract.id}')">🧾 Facturer</button>
              <button class="btn btn-danger btn-sm" style="margin-left:8px;font-size:10px;" onclick="terminateContract('${group.ownerContract.id}')">Résilier</button>`
           : `<button class="btn btn-primary btn-sm" style="margin-left:10px;font-size:10px;" onclick="openContractForClient('${ownId}', 'owner')">+ Contrat proprio</button>`}
       </td>
@@ -1284,8 +1696,11 @@ async function loadContracts() {
       const paidBadge = c.paid_until
         ? `<span class="badge ${paidLate ? 'badge-red' : 'badge-green'}" style="font-size:10px;">${paidLate ? '⚠ Impayé depuis ' + c.paid_until : '✓ ' + c.paid_until}</span>`
         : `<span class="badge badge-gray" style="font-size:10px;">—</span>`;
+      const upgradeBadge = c.upgrade_requested_to_plan
+        ? `<br><span class="badge badge-yellow" style="font-size:10px;margin-top:4px;" title="Demande le ${c.upgrade_requested_at ? new Date(c.upgrade_requested_at).toLocaleDateString('fr-CA') : ''}">⬆ Demande ${c.upgrade_requested_to_plan}</span>`
+        : '';
       rows.push(`<tr style="${c.status === 'terminated' ? 'opacity:.5' : (c.status === 'suspended' || paidLate) ? 'background:rgba(224,112,96,.06);' : ''}">
-        <td style="padding-left:28px;"><strong>${resName}</strong><br><span style="font-size:11px;color:var(--text3)">${resEmail}</span></td>
+        <td style="padding-left:28px;"><strong>${resName}</strong><br><span style="font-size:11px;color:var(--text3)">${resEmail}</span>${upgradeBadge}</td>
         <td>${planLabels[c.plan] || c.plan || '—'}</td>
         <td style="font-size:12px">${c.starts_at || '—'}</td>
         <td style="font-size:12px">${c.ends_at || '∞'}</td>
@@ -1294,7 +1709,8 @@ async function loadContracts() {
         <td><div class="td-actions">
           <button class="btn btn-info btn-sm" onclick="showClientContracts('${c.client_id}', '${resName.replace(/'/g, "\'")}', 'resident')">📄 Contrat</button>
           ${!c.signed_at && c.status !== 'terminated' ? `<button class="btn btn-info btn-sm" onclick="sendSignatureLink('${c.id}', this)">✍ Lien signature</button>` : ''}
-          <button class="btn btn-success btn-sm" onclick="renewPayment('${c.id}')">💳 +1 mois</button>
+          ${c.status !== 'terminated' ? `<button class="btn btn-primary btn-sm" onclick="openGenerateInvoiceModal('${c.id}')">🧾 Facturer</button>` : ''}
+          ${c.upgrade_requested_to_plan ? `<button class="btn btn-success btn-sm" onclick="approvePlanUpgrade('${c.id}')">✓ Upgrade</button><button class="btn btn-danger btn-sm" onclick="rejectPlanUpgrade('${c.id}')">✕</button>` : ''}
           ${canSuspend && paidLate ? `<button class="btn btn-warning btn-sm" onclick="suspendForNonPayment('${c.id}')">🔒 Suspendre</button>` : ''}
           ${canReactivate ? `<button class="btn btn-warning btn-sm" onclick="suspendForNonPayment('${c.id}')">🔒 Suspendre</button>` : ''}
           ${canTerminate  ? `<button class="btn btn-danger btn-sm" onclick="terminateContract('${c.id}')">Résilier</button>` : ''}

--- a/sql/001_signature_tokens.sql
+++ b/sql/001_signature_tokens.sql
@@ -1,0 +1,125 @@
+-- =====================================================================
+-- Migration : tokens de signature pour contrats
+-- Central DB Modulimo (bpxscgrbxjscicpnheep)
+-- =====================================================================
+-- Permet à un client (résident ou propriétaire) de signer son contrat
+-- via un lien email tokenisé, sans avoir accès à modulimo-admin ni à
+-- une session authentifiée dans cohabitat.
+--
+-- Appliquer sur le projet Central (bpxscgrbxjscicpnheep) :
+--   psql "postgresql://postgres.bpxscgrbxjscicpnheep:[PWD]@...:5432/postgres" \
+--        -f sql/001_signature_tokens.sql
+-- =====================================================================
+
+BEGIN;
+
+-- 1. Colonnes token sur contracts
+ALTER TABLE contracts
+  ADD COLUMN IF NOT EXISTS signature_token            text UNIQUE,
+  ADD COLUMN IF NOT EXISTS signature_token_expires_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_contracts_signature_token
+  ON contracts(signature_token)
+  WHERE signature_token IS NOT NULL;
+
+-- 2. RPC lecture : renvoie le contrat + les infos client/immeuble à partir du token
+--    SECURITY DEFINER → contourne RLS, exposé à anon pour la page publique sign.html
+CREATE OR REPLACE FUNCTION public.get_contract_by_token(p_token text)
+RETURNS TABLE(
+  id               uuid,
+  type             text,
+  plan             text,
+  status           text,
+  starts_at        date,
+  ends_at          date,
+  signed_at        timestamptz,
+  signed_by_name   text,
+  client_name      text,
+  client_email     text,
+  owner_name       text,
+  token_expired    boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    c.id, c.type, c.plan, c.status, c.starts_at, c.ends_at,
+    c.signed_at, c.signed_by_name,
+    COALESCE(cli.contact_name, cli.name) AS client_name,
+    cli.contact_email                    AS client_email,
+    own.name                             AS owner_name,
+    (c.signature_token_expires_at IS NOT NULL
+       AND c.signature_token_expires_at < now())      AS token_expired
+  FROM contracts c
+  LEFT JOIN clients cli ON cli.id = c.client_id
+  LEFT JOIN clients own ON own.id = c.owner_client_id
+  WHERE c.signature_token = p_token;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_contract_by_token(text) FROM public;
+GRANT EXECUTE ON FUNCTION public.get_contract_by_token(text) TO anon, authenticated;
+
+-- 3. RPC signature : enregistre la signature et invalide le token (one-shot)
+--    Retourne l'id du contrat signé ; lève une erreur si token invalide/expiré/déjà utilisé
+CREATE OR REPLACE FUNCTION public.sign_contract_with_token(
+  p_token           text,
+  p_signed_by_name  text,
+  p_signature_data  text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  IF p_token IS NULL OR length(p_token) < 20 THEN
+    RAISE EXCEPTION 'Token invalide';
+  END IF;
+  IF p_signed_by_name IS NULL OR length(trim(p_signed_by_name)) < 2 THEN
+    RAISE EXCEPTION 'Nom de signataire requis';
+  END IF;
+  IF p_signature_data IS NULL OR length(p_signature_data) < 100 THEN
+    RAISE EXCEPTION 'Signature requise';
+  END IF;
+
+  UPDATE contracts
+     SET signed_at                  = now(),
+         signed_by_name             = p_signed_by_name,
+         signature_data             = p_signature_data,
+         signature_token            = NULL,
+         signature_token_expires_at = NULL
+   WHERE signature_token = p_token
+     AND signed_at IS NULL
+     AND (signature_token_expires_at IS NULL OR signature_token_expires_at > now())
+  RETURNING id INTO v_id;
+
+  IF v_id IS NULL THEN
+    RAISE EXCEPTION 'Lien invalide, expiré ou déjà utilisé';
+  END IF;
+
+  RETURN v_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.sign_contract_with_token(text, text, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.sign_contract_with_token(text, text, text) TO anon, authenticated;
+
+COMMIT;
+
+-- =====================================================================
+-- Rollback (à conserver pour référence)
+-- =====================================================================
+-- BEGIN;
+-- DROP FUNCTION IF EXISTS public.sign_contract_with_token(text, text, text);
+-- DROP FUNCTION IF EXISTS public.get_contract_by_token(text);
+-- DROP INDEX  IF EXISTS public.idx_contracts_signature_token;
+-- ALTER TABLE contracts
+--   DROP COLUMN IF EXISTS signature_token_expires_at,
+--   DROP COLUMN IF EXISTS signature_token;
+-- COMMIT;

--- a/sql/002_billing_invoices.sql
+++ b/sql/002_billing_invoices.sql
@@ -1,0 +1,262 @@
+-- =====================================================================
+-- Migration : facturation + paiements manuels (sans Stripe)
+-- Central DB Modulimo (bpxscgrbxjscicpnheep)
+-- =====================================================================
+-- Apporte : factures détaillées par résident (frais mensuel + usage),
+-- enregistrement manuel des paiements (cash/virement/chèque), mode de
+-- collecte (proprio ou Modulimo) hérité du plan proprio, % commission
+-- unique dans app_config, demande d'upgrade Local→Réseau par le résident.
+-- =====================================================================
+
+BEGIN;
+
+-- 1. Colonnes tarification
+ALTER TABLE plans
+  ADD COLUMN IF NOT EXISTS price_monthly numeric(10,2) DEFAULT 0;
+
+ALTER TABLE contracts
+  ADD COLUMN IF NOT EXISTS monthly_amount             numeric(10,2),
+  ADD COLUMN IF NOT EXISTS billing_mode               text DEFAULT 'owner_collects'
+    CHECK (billing_mode IN ('owner_collects','modulimo_collects')),
+  ADD COLUMN IF NOT EXISTS upgrade_requested_to_plan  text,
+  ADD COLUMN IF NOT EXISTS upgrade_requested_at       timestamptz;
+
+-- 2. Seed du taux de commission unique (si absent)
+INSERT INTO app_config (key, value)
+  SELECT 'modulimo_commission_pct', '5'
+  WHERE NOT EXISTS (SELECT 1 FROM app_config WHERE key = 'modulimo_commission_pct');
+
+-- 3. Factures
+CREATE TABLE IF NOT EXISTS invoices (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  contract_id         uuid NOT NULL REFERENCES contracts(id) ON DELETE CASCADE,
+  client_id           uuid NOT NULL REFERENCES clients(id),
+  owner_client_id     uuid REFERENCES clients(id),
+  period_start        date NOT NULL,
+  period_end          date NOT NULL,
+  issued_at           timestamptz DEFAULT now(),
+  due_at              date,
+  monthly_fee         numeric(10,2) NOT NULL DEFAULT 0,
+  services_subtotal   numeric(10,2) NOT NULL DEFAULT 0,
+  total_amount        numeric(10,2) NOT NULL DEFAULT 0,
+  commission_pct      numeric(5,2)  NOT NULL DEFAULT 0,
+  commission_amount   numeric(10,2) NOT NULL DEFAULT 0,
+  net_to_owner        numeric(10,2) NOT NULL DEFAULT 0,
+  billing_mode        text NOT NULL DEFAULT 'owner_collects'
+                      CHECK (billing_mode IN ('owner_collects','modulimo_collects')),
+  status              text NOT NULL DEFAULT 'issued'
+                      CHECK (status IN ('draft','issued','paid','overdue','cancelled')),
+  paid_at             timestamptz,
+  paid_method         text,
+  paid_by             text,
+  notes               text,
+  created_at          timestamptz DEFAULT now(),
+  updated_at          timestamptz DEFAULT now(),
+  UNIQUE (contract_id, period_start, period_end)
+);
+
+CREATE INDEX IF NOT EXISTS idx_invoices_client     ON invoices(client_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_owner      ON invoices(owner_client_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_contract   ON invoices(contract_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_status     ON invoices(status);
+CREATE INDEX IF NOT EXISTS idx_invoices_period_end ON invoices(period_end);
+
+CREATE TABLE IF NOT EXISTS invoice_line_items (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  invoice_id        uuid NOT NULL REFERENCES invoices(id) ON DELETE CASCADE,
+  category          text NOT NULL DEFAULT 'other'
+                    CHECK (category IN ('monthly_fee','space_reservation','trip','trip_charge','lunch','other')),
+  description       text NOT NULL,
+  quantity          numeric(10,2) NOT NULL DEFAULT 1,
+  unit_amount       numeric(10,2) NOT NULL DEFAULT 0,
+  total_amount      numeric(10,2) NOT NULL DEFAULT 0,
+  transaction_ref   text,            -- id de la transaction tenant (optionnel)
+  transaction_date  timestamptz,
+  created_at        timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_invoice_lines_invoice ON invoice_line_items(invoice_id);
+
+-- 4. RPC : enregistrer un paiement sur une facture (manuel, cash/etransfer/etc.)
+--    Met la facture à 'paid', met à jour contracts.paid_until au period_end
+--    et réactive un contrat suspendu le cas échéant.
+CREATE OR REPLACE FUNCTION public.record_invoice_payment(
+  p_invoice_id  uuid,
+  p_method      text DEFAULT 'cash',
+  p_paid_by     text DEFAULT NULL,
+  p_notes       text DEFAULT NULL
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_inv RECORD;
+BEGIN
+  SELECT * INTO v_inv FROM invoices WHERE id = p_invoice_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Facture introuvable'; END IF;
+  IF v_inv.status = 'paid' THEN RAISE EXCEPTION 'Facture déjà payée'; END IF;
+
+  UPDATE invoices
+     SET status      = 'paid',
+         paid_at     = now(),
+         paid_method = COALESCE(p_method, 'cash'),
+         paid_by     = p_paid_by,
+         notes       = CASE WHEN p_notes IS NULL OR p_notes = '' THEN notes
+                            ELSE COALESCE(notes || E'\n', '') || p_notes END,
+         updated_at  = now()
+   WHERE id = p_invoice_id;
+
+  UPDATE contracts
+     SET paid_until = GREATEST(COALESCE(paid_until, '1970-01-01'::date), v_inv.period_end),
+         status     = CASE WHEN status = 'suspended' THEN 'active' ELSE status END
+   WHERE id = v_inv.contract_id;
+
+  RETURN p_invoice_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_invoice_payment(uuid, text, text, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.record_invoice_payment(uuid, text, text, text) TO anon, authenticated;
+
+-- 5. RPC : demande d'upgrade de forfait par le résident depuis CoHabitat
+CREATE OR REPLACE FUNCTION public.request_plan_upgrade(
+  p_cohabitat_user_id uuid,
+  p_target_plan       text
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_client_id   uuid;
+  v_contract_id uuid;
+BEGIN
+  IF p_target_plan NOT IN ('local','network') THEN
+    RAISE EXCEPTION 'Plan invalide';
+  END IF;
+
+  SELECT id INTO v_client_id FROM clients
+   WHERE cohabitat_user_id = p_cohabitat_user_id LIMIT 1;
+  IF v_client_id IS NULL THEN RAISE EXCEPTION 'Client introuvable'; END IF;
+
+  SELECT id INTO v_contract_id FROM contracts
+   WHERE client_id = v_client_id
+     AND type      = 'resident'
+     AND status IN ('active','suspended')
+   ORDER BY created_at DESC LIMIT 1;
+  IF v_contract_id IS NULL THEN RAISE EXCEPTION 'Aucun contrat actif'; END IF;
+
+  UPDATE contracts
+     SET upgrade_requested_to_plan = p_target_plan,
+         upgrade_requested_at      = now()
+   WHERE id = v_contract_id;
+
+  RETURN v_contract_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.request_plan_upgrade(uuid, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.request_plan_upgrade(uuid, text) TO anon, authenticated;
+
+-- 6. RPC : lister les factures d'un résident (lecture sécurisée pour CoHabitat)
+CREATE OR REPLACE FUNCTION public.list_client_invoices(p_cohabitat_user_id uuid)
+RETURNS TABLE(
+  id                uuid,
+  period_start      date,
+  period_end        date,
+  issued_at         timestamptz,
+  due_at            date,
+  monthly_fee       numeric,
+  services_subtotal numeric,
+  total_amount      numeric,
+  status            text,
+  paid_at           timestamptz,
+  paid_method       text,
+  billing_mode      text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_client_id uuid;
+BEGIN
+  SELECT id INTO v_client_id FROM clients
+   WHERE cohabitat_user_id = p_cohabitat_user_id LIMIT 1;
+  IF v_client_id IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  SELECT i.id, i.period_start, i.period_end, i.issued_at, i.due_at,
+         i.monthly_fee, i.services_subtotal, i.total_amount,
+         i.status, i.paid_at, i.paid_method, i.billing_mode
+    FROM invoices i
+   WHERE i.client_id = v_client_id
+   ORDER BY i.period_end DESC;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.list_client_invoices(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.list_client_invoices(uuid) TO anon, authenticated;
+
+-- 7. RPC : détail d'une facture (lignes) pour CoHabitat
+CREATE OR REPLACE FUNCTION public.get_invoice_detail(
+  p_invoice_id        uuid,
+  p_cohabitat_user_id uuid
+) RETURNS TABLE(
+  line_id           uuid,
+  category          text,
+  description       text,
+  quantity          numeric,
+  unit_amount       numeric,
+  total_amount      numeric,
+  transaction_date  timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_client_id uuid;
+  v_owned_by  uuid;
+BEGIN
+  SELECT id INTO v_client_id FROM clients
+   WHERE cohabitat_user_id = p_cohabitat_user_id LIMIT 1;
+  IF v_client_id IS NULL THEN RETURN; END IF;
+
+  SELECT client_id INTO v_owned_by FROM invoices WHERE id = p_invoice_id;
+  IF v_owned_by IS NULL OR v_owned_by <> v_client_id THEN RETURN; END IF;
+
+  RETURN QUERY
+  SELECT l.id, l.category, l.description,
+         l.quantity, l.unit_amount, l.total_amount,
+         l.transaction_date
+    FROM invoice_line_items l
+   WHERE l.invoice_id = p_invoice_id
+   ORDER BY l.transaction_date NULLS FIRST, l.created_at;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_invoice_detail(uuid, uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.get_invoice_detail(uuid, uuid) TO anon, authenticated;
+
+COMMIT;
+
+-- =====================================================================
+-- Rollback
+-- =====================================================================
+-- BEGIN;
+-- DROP FUNCTION IF EXISTS public.get_invoice_detail(uuid, uuid);
+-- DROP FUNCTION IF EXISTS public.list_client_invoices(uuid);
+-- DROP FUNCTION IF EXISTS public.request_plan_upgrade(uuid, text);
+-- DROP FUNCTION IF EXISTS public.record_invoice_payment(uuid, text, text, text);
+-- DROP TABLE IF EXISTS invoice_line_items;
+-- DROP TABLE IF EXISTS invoices;
+-- DELETE FROM app_config WHERE key = 'modulimo_commission_pct';
+-- ALTER TABLE contracts
+--   DROP COLUMN IF EXISTS upgrade_requested_at,
+--   DROP COLUMN IF EXISTS upgrade_requested_to_plan,
+--   DROP COLUMN IF EXISTS billing_mode,
+--   DROP COLUMN IF EXISTS monthly_amount;
+-- ALTER TABLE plans DROP COLUMN IF EXISTS price_monthly;
+-- COMMIT;


### PR DESCRIPTION
## Résumé

Centralise la gestion des contrats dans modulimo-admin — ajoute un flux de signature tokenisée envoyée par email, qui permet aux clients (résidents et propriétaires) de signer leur contrat sans avoir accès à modulimo-admin.

## Changements

### `index.html`
- Nouveau bouton **✍ Lien signature** sur chaque contrat non signé (résidents, propriétaires, orphelins, et modal par-client)
- Nouvelle fonction `sendSignatureLink()` : génère un token aléatoire (32 octets → base64url), le stocke sur `contracts.signature_token` avec expiration à 14 jours, puis envoie un email au client
- Nouveau template d'email `signature_request` avec CTA pointant vers `https://cohabitat.modulimo.com/sign.html?token=...`
- Constantes `SIGN_BASE_URL` et `SIGN_EXPIRY_DAYS` configurables

### `sql/001_signature_tokens.sql` (migration Central DB — **déjà appliquée**)
- `ALTER TABLE contracts ADD signature_token text UNIQUE + signature_token_expires_at timestamptz`
- Index partiel sur `signature_token`
- `get_contract_by_token(text)` RPC `SECURITY DEFINER` — lit le contrat depuis la page publique via le token
- `sign_contract_with_token(text, text, text)` RPC `SECURITY DEFINER` — enregistre la signature et invalide le token (one-shot)
- `GRANT EXECUTE` pour `anon` et `authenticated`

## Dépendance

Fonctionne de pair avec la PR cohabitat qui ajoute `sign.html` (la page publique de signature).

## Test manuel

- [ ] Cliquer « ✍ Lien signature » sur un contrat test
- [ ] Vérifier l'email reçu
- [ ] Cliquer le lien → page publique s'affiche → signer
- [ ] Vérifier en base : `signed_at`, `signed_by_name`, `signature_data` remplis ; `signature_token` à NULL