### PR TITLE
Fix CORS Resend via Edge Function + fix SQL record_invoice_payment + visibilité erreurs email

### DIFF
--- a/index.html
+++ b/index.html
@@ -1004,33 +1004,26 @@ async function sendContractEmail(to, name, type, details) {
       </div>`,
   };
 
-  if(!RESEND_KEY) {
-    console.warn('[email] RESEND_KEY manquante dans app_config — aucun email envoyé');
-    return { ok: false, error: 'RESEND_KEY manquante (app_config)' };
-  }
+  // On passe par l'Edge Function Supabase 'send-email' — l'appel direct à
+  // api.resend.com est bloqué par CORS depuis le navigateur. La clé Resend
+  // reste côté serveur (secret de la fonction).
   try {
-    const res = await fetch('https://api.resend.com/emails', {
-      method: 'POST',
-      headers: {
-        'Authorization': 'Bearer ' + RESEND_KEY,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        from: RESEND_FROM,
-        to: [to],
-        subject: subjects[type],
-        html: bodies[type]
-      })
+    const { data, error } = await sb.functions.invoke('send-email', {
+      body: { to, subject: subjects[type], html: bodies[type] }
     });
-    if(!res.ok) {
-      const body = await res.text();
-      console.warn('[email] Resend HTTP ' + res.status + ':', body);
-      return { ok: false, error: 'Resend ' + res.status + ': ' + body.slice(0,140) };
+    if(error) {
+      console.warn('[email] Edge function error:', error.message);
+      return { ok: false, error: error.message };
+    }
+    if(data && data.ok === false) {
+      const msg = typeof data.error === 'string' ? data.error : JSON.stringify(data.error).slice(0,140);
+      console.warn('[email] Resend rejet:', data.status, msg);
+      return { ok: false, error: 'Resend ' + (data.status || '') + ': ' + msg };
     }
     console.log('[email] Envoyé à', to, '— type:', type);
     return { ok: true };
   } catch(e) {
-    console.warn('[email] Erreur envoi:', e.message);
+    console.warn('[email] Exception:', e.message);
     return { ok: false, error: e.message };
   }
 }

--- a/index.html
+++ b/index.html
@@ -1004,8 +1004,12 @@ async function sendContractEmail(to, name, type, details) {
       </div>`,
   };
 
+  if(!RESEND_KEY) {
+    console.warn('[email] RESEND_KEY manquante dans app_config — aucun email envoyé');
+    return { ok: false, error: 'RESEND_KEY manquante (app_config)' };
+  }
   try {
-    await fetch('https://api.resend.com/emails', {
+    const res = await fetch('https://api.resend.com/emails', {
       method: 'POST',
       headers: {
         'Authorization': 'Bearer ' + RESEND_KEY,
@@ -1018,9 +1022,16 @@ async function sendContractEmail(to, name, type, details) {
         html: bodies[type]
       })
     });
+    if(!res.ok) {
+      const body = await res.text();
+      console.warn('[email] Resend HTTP ' + res.status + ':', body);
+      return { ok: false, error: 'Resend ' + res.status + ': ' + body.slice(0,140) };
+    }
     console.log('[email] Envoyé à', to, '— type:', type);
+    return { ok: true };
   } catch(e) {
     console.warn('[email] Erreur envoi:', e.message);
+    return { ok: false, error: e.message };
   }
 }
 
@@ -1074,14 +1085,18 @@ async function sendSignatureLink(contractId, btn) {
 
     const url = SIGN_BASE_URL + '?token=' + encodeURIComponent(token);
 
-    await sendContractEmail(
+    const mail = await sendContractEmail(
       signer.contact_email,
       signer.contact_name || signer.name || 'Client',
       'signature_request',
       { url, building: buildingName, contractType: c.type, expiresDays: SIGN_EXPIRY_DAYS }
     );
 
-    toast('✍ Lien de signature envoyé à ' + signer.contact_email, 'success');
+    if(mail && mail.ok === false) {
+      toast('⚠ Lien créé mais email NON envoyé : ' + mail.error, 'error');
+    } else {
+      toast('✍ Lien de signature envoyé à ' + signer.contact_email, 'success');
+    }
   } catch(e) {
     console.error('[sendSignatureLink]', e);
     toast('Erreur: ' + e.message, 'error');

--- a/sql/002_billing_invoices.sql
+++ b/sql/002_billing_invoices.sql
@@ -91,11 +91,17 @@ SECURITY DEFINER
 SET search_path = public
 AS $$
 DECLARE
-  v_inv RECORD;
+  v_status      text;
+  v_contract_id uuid;
+  v_period_end  date;
 BEGIN
-  SELECT * INTO v_inv FROM invoices WHERE id = p_invoice_id;
+  SELECT status, contract_id, period_end
+    INTO v_status, v_contract_id, v_period_end
+    FROM invoices
+   WHERE id = p_invoice_id;
+
   IF NOT FOUND THEN RAISE EXCEPTION 'Facture introuvable'; END IF;
-  IF v_inv.status = 'paid' THEN RAISE EXCEPTION 'Facture déjà payée'; END IF;
+  IF v_status = 'paid' THEN RAISE EXCEPTION 'Facture déjà payée'; END IF;
 
   UPDATE invoices
      SET status      = 'paid',
@@ -103,14 +109,14 @@ BEGIN
          paid_method = COALESCE(p_method, 'cash'),
          paid_by     = p_paid_by,
          notes       = CASE WHEN p_notes IS NULL OR p_notes = '' THEN notes
-                            ELSE COALESCE(notes || E'\n', '') || p_notes END,
+                            ELSE COALESCE(notes || chr(10), '') || p_notes END,
          updated_at  = now()
    WHERE id = p_invoice_id;
 
   UPDATE contracts
-     SET paid_until = GREATEST(COALESCE(paid_until, '1970-01-01'::date), v_inv.period_end),
+     SET paid_until = GREATEST(COALESCE(paid_until, '1970-01-01'::date), v_period_end),
          status     = CASE WHEN status = 'suspended' THEN 'active' ELSE status END
-   WHERE id = v_inv.contract_id;
+   WHERE id = v_contract_id;
 
   RETURN p_invoice_id;
 END;

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -1,0 +1,85 @@
+// Edge Function Supabase : proxy d'envoi de courriels via Resend
+// -----------------------------------------------------------------------
+// Pourquoi : l'API Resend (api.resend.com) bloque les appels browser-origin
+// par CORS. Cette fonction s'exécute côté serveur (Deno), tient la clé
+// RESEND_KEY en secret et retourne les headers CORS nécessaires pour que
+// modulimo-admin et cohabitat puissent l'appeler depuis le navigateur.
+//
+// Déploiement :
+//   supabase functions deploy send-email --project-ref bpxscgrbxjscicpnheep
+//   supabase secrets set RESEND_KEY=re_xxx   --project-ref bpxscgrbxjscicpnheep
+//   supabase secrets set RESEND_FROM='Modulimo <no-reply@modulimo.com>' --project-ref bpxscgrbxjscicpnheep
+//
+// Alternative dashboard : Supabase → Edge Functions → New Function
+// "send-email" → coller ce fichier → Deploy, puis configurer les secrets.
+//
+// Appel côté client (JS) :
+//   const { data, error } = await sb.functions.invoke('send-email', {
+//     body: { to, subject, html }
+//   });
+// -----------------------------------------------------------------------
+
+const RESEND_KEY  = Deno.env.get('RESEND_KEY')  ?? '';
+const RESEND_FROM = Deno.env.get('RESEND_FROM') ?? 'Modulimo <no-reply@modulimo.com>';
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin':  '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, content-type, apikey, x-client-info',
+  'Access-Control-Max-Age':       '86400',
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, 'content-type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response(null, { headers: CORS_HEADERS });
+  if (req.method !== 'POST')    return json({ error: 'Method not allowed' }, 405);
+
+  if (!RESEND_KEY) {
+    return json({ error: 'RESEND_KEY secret non configuré sur la fonction' }, 500);
+  }
+
+  let payload: any;
+  try {
+    payload = await req.json();
+  } catch {
+    return json({ error: 'Corps JSON invalide' }, 400);
+  }
+
+  const { to, subject, html, from, reply_to } = payload ?? {};
+  if (!to || !subject || !html) {
+    return json({ error: 'Champs requis: to, subject, html' }, 400);
+  }
+  const recipients = Array.isArray(to) ? to : [to];
+
+  const resendRes = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${RESEND_KEY}`,
+      'Content-Type':  'application/json',
+    },
+    body: JSON.stringify({
+      from:     from || RESEND_FROM,
+      to:       recipients,
+      subject,
+      html,
+      reply_to: reply_to || undefined,
+    }),
+  });
+
+  const text = await resendRes.text();
+  let body: any = text;
+  try { body = JSON.parse(text); } catch { /* keep text */ }
+
+  return json(
+    resendRes.ok
+      ? { ok: true, provider: 'resend', data: body }
+      : { ok: false, provider: 'resend', status: resendRes.status, error: body },
+    resendRes.ok ? 200 : resendRes.status
+  );
+});


### PR DESCRIPTION
## Résumé

Suite de la PR #1. Corrige le CORS bloquant Resend + ajoute visibilité des erreurs email + fix SQL `record_invoice_payment` + livre l'Edge Function qui doit être déployée côté Supabase.

## Commits inclus

- `4b78006` — Surfacer les erreurs d'envoi Resend au lieu d'avaler silencieusement
- `7ebdcd0` — Fix SQL : remplacer RECORD par variables explicites dans `record_invoice_payment` (évite l'erreur `42P01` du SQL Editor Supabase)
- `c31d5c7` — **Router l'envoi d'emails via une Edge Function Supabase** (CORS fix — Resend bloque les appels browser-origin depuis `simonvelucia-afk.github.io`)

## Déploiement requis côté Supabase

1. **Edge Function** : déployer `supabase/functions/send-email/index.ts` (déjà fait via le dashboard d'après nos échanges)
2. **Secrets de la fonction** :
   - `RESEND_KEY` = la clé Resend (récupérable via `SELECT value FROM app_config WHERE key='resend_key'`)
   - `RESEND_FROM` = `Modulimo <no-reply@modulimo.com>` (optionnel)
3. **SQL** : si `record_invoice_payment` n'a pas été créée à cause du bug 42P01, exécuter le bloc de correction livré dans `sql/002_billing_invoices.sql` (version à jour)

## Test post-merge

- Hard refresh modulimo-admin
- Cliquer « Lien signature » sur un contrat non signé
- Le réseau DevTools doit montrer un POST vers `supabase.co/functions/v1/send-email` (plus vers `api.resend.com`)
- Toast vert = email parti ; toast rouge = message d'erreur explicite