### PR TITLE
Migration 006 : exp_date sur lunch_menus et lunch_slots

### DIFF
--- a/sql/006_lunch_menus_slots_expdate.sql
+++ b/sql/006_lunch_menus_slots_expdate.sql
@@ -1,0 +1,17 @@
+-- 006_lunch_menus_slots_expdate.sql
+-- A deployer sur modulimo-central (bpxscgrbxjscicpnheep).
+--
+-- Contexte : un menu peut avoir une date d'expiration (ex : sandwich avec
+-- DLC). Quand le menu est charge dans une case de la machine, la case
+-- herite de cette date. La page Status du kiosque affiche le nombre de
+-- jours restants et encadre la case en rouge si la date est depassee.
+
+ALTER TABLE lunch_menus
+  ADD COLUMN IF NOT EXISTS exp_date DATE;
+
+ALTER TABLE lunch_slots
+  ADD COLUMN IF NOT EXISTS exp_date DATE;
+
+-- Forcer PostgREST a relire le schema pour exposer immediatement la
+-- nouvelle colonne via l'API REST.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Migration 006 ajoute `exp_date DATE` sur `lunch_menus` et `lunch_slots` pour la nouvelle feature "date d'expiration sur menu" :
- Quand un menu avec exp_date est chargé dans une case, la case hérite de la date
- L'onglet Statuts du kiosque affiche "Reste N j" et encadre en rouge si dépassé

NOTIFY pgrst en fin pour exposer la nouvelle colonne via REST sans attendre.

## Deployment
À déployer sur Supabase **`bpxscgrbxjscicpnheep`** (modulimo-central).

## PR associée
- LunchMachine (à venir) : utilise `exp_date` côté UI/JS

https://claude.ai/code/session_01JD6D94k4hxPtZFwSToSXMo