### PR TITLE
Solde central : Edge Function + schéma + RPC get_balance/lunch_purchase

### DIFF
--- a/scripts/register-building.sql.example
+++ b/scripts/register-building.sql.example
@@ -1,0 +1,40 @@
+-- Template : inscrire un immeuble dans le registre central.
+-- A executer sur la DB centrale bpxscgrbxjscicpnheep apres avoir
+-- applique la migration sql/007_finance_central_phase1.sql.
+--
+-- Avant de lancer :
+--   1. Remplacer <PROJECT_REF> par le ref Supabase du projet immeuble
+--      (ex: uwyhrdjlwetcbtskijrs pour Pointe Est).
+--   2. Remplacer <NOM_IMMEUBLE> par le nom lisible.
+--   3. Verifier que le JWKS endpoint retourne bien une liste de cles non
+--      vide :
+--        curl -s https://<PROJECT_REF>.supabase.co/auth/v1/.well-known/jwks.json | jq
+--      Si `.keys` est vide, activer l'asymetrique dans Supabase Dashboard
+--      -> Auth -> JWT Settings avant de continuer (la verification de
+--      signature est impossible sans JWKS public).
+
+BEGIN;
+
+INSERT INTO building_registry (name, supabase_url, jwt_issuer, jwks_url, status)
+VALUES (
+  '<NOM_IMMEUBLE>',
+  'https://<PROJECT_REF>.supabase.co',
+  'https://<PROJECT_REF>.supabase.co/auth/v1',
+  'https://<PROJECT_REF>.supabase.co/auth/v1/.well-known/jwks.json',
+  'active'
+)
+RETURNING id, name;
+
+-- Apres INSERT, noter le `id` retourne : il servira a backfiller
+-- clients.building_id pour les residents de cet immeuble.
+-- Exemple de backfill (a adapter) :
+--
+--   UPDATE clients
+--      SET building_id = '<BUILDING_ID_RETOURNE>'
+--    WHERE id IN (
+--      SELECT DISTINCT client_id
+--        FROM contracts
+--       WHERE ... -- critere qui identifie les contrats de cet immeuble
+--    );
+
+COMMIT;

--- a/scripts/smoke-test-finance-bridge.sh
+++ b/scripts/smoke-test-finance-bridge.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Smoke test de la Phase 1 : appelle /finance-bridge/get-balance avec un
+# JWT reel emis par l'Auth Supabase d'un immeuble, et verifie qu'on
+# obtient une reponse structuree (peu importe la valeur du solde).
+#
+# Pre-requis :
+#   1. Migration 007_finance_central_phase1.sql appliquee sur la centrale.
+#   2. Au moins un immeuble inscrit dans building_registry (voir
+#      scripts/register-building.sql.example).
+#   3. Le resident a un row clients avec le bon cohabitat_user_id et
+#      building_id (backfill manuel).
+#   4. Edge Function deployee :
+#        supabase functions deploy finance-bridge --project-ref <CENTRAL_REF>
+#   5. Un JWT valide recupere depuis le projet immeuble :
+#        - Se connecter dans CoHabitat
+#        - Console DevTools :
+#            (await sb.auth.getSession()).data.session.access_token
+#
+# Usage :
+#   CENTRAL_URL=https://bpxscgrbxjscicpnheep.supabase.co \
+#   CENTRAL_ANON_KEY=ey... \
+#   BUILDING_JWT=ey... \
+#   ./scripts/smoke-test-finance-bridge.sh
+
+set -euo pipefail
+
+: "${CENTRAL_URL:?CENTRAL_URL requis (ex: https://bpxscgrbxjscicpnheep.supabase.co)}"
+: "${CENTRAL_ANON_KEY:?CENTRAL_ANON_KEY requis (cle anon du projet central)}"
+: "${BUILDING_JWT:?BUILDING_JWT requis (access_token d'un resident authentifie)}"
+
+URL="${CENTRAL_URL}/functions/v1/finance-bridge/get-balance"
+
+echo ">>> POST ${URL}"
+echo ">>> JWT len : ${#BUILDING_JWT}"
+echo
+
+response=$(mktemp)
+status=$(curl -sS -o "${response}" -w '%{http_code}' \
+  -X POST "${URL}" \
+  -H "Authorization: Bearer ${BUILDING_JWT}" \
+  -H "Content-Type: application/json" \
+  -H "apikey: ${CENTRAL_ANON_KEY}" \
+  --data '{"dependent_id": null}')
+
+echo "=== HTTP ${status} ==="
+if command -v jq >/dev/null 2>&1; then
+  jq . < "${response}" || cat "${response}"
+else
+  cat "${response}"
+fi
+echo
+
+case "${status}" in
+  200) echo "OK : la phase 1 tourne de bout en bout." ;;
+  401) echo "JWT rejete cote Edge Function. Verifier :"
+       echo "  - JWKS de l'immeuble expose ? (curl .../jwks.json)"
+       echo "  - JWT non expire ?"
+       echo "  - Audience = 'authenticated' ?" ;;
+  403) echo "Authenticated mais acces refuse. Verifier :"
+       echo "  - L'immeuble est-il dans building_registry et 'active' ?"
+       echo "  - Le cohabitat_user_id existe-t-il dans clients avec le bon building_id ?" ;;
+  404) echo "Endpoint introuvable. Edge Function deployee ? (supabase functions list)" ;;
+  502) echo "La RPC centrale a echoue. Verifier les logs PostgREST." ;;
+  *)   echo "Code inattendu." ;;
+esac
+
+rm -f "${response}"

--- a/sql/007_finance_central_phase1.sql
+++ b/sql/007_finance_central_phase1.sql
@@ -1,0 +1,335 @@
+-- =====================================================================
+-- 007_finance_central_phase1.sql
+-- Migration : fondation du solde central Modulimo (Phase 1 du plan
+-- "solde central"). Pose le schema sans deplacer encore les donnees
+-- depuis les DBs CoHabitat des immeubles — ce sera la Phase 3 (dual-write
+-- puis bascule). Ici on cree seulement :
+--   * building_registry  : table de confiance consultee par l'Edge
+--                          Function finance-bridge pour valider les JWT
+--                          emis par l'Auth Supabase de chaque immeuble.
+--   * clients.building_id: scoping explicite par immeuble (aujourd'hui
+--                          derive implicitement des contracts).
+--   * balances, dependent_balances : source de verite du solde virtuel,
+--                          scope par (client_id, building_id).
+--   * transactions       : ledger append-only, un seul schema pour tous
+--                          les immeubles au lieu de N schemas CoHabitat.
+--   * helpers JWT + RLS  : jwt_building_id(), jwt_client_id() lisent le
+--                          claim injecte par l'Edge Function.
+--   * RPC get_balance    : lecture sure (SECURITY DEFINER, scope sur les
+--                          claims JWT, aucune confiance dans le body).
+--
+-- Central DB cible : bpxscgrbxjscicpnheep
+-- Edge Function appelante : supabase/functions/finance-bridge
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. Extensions
+-- ---------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ---------------------------------------------------------------------
+-- 2. building_registry — source de verite des projets Supabase immeubles
+-- ---------------------------------------------------------------------
+-- Chaque row represente un immeuble branche sur la centrale. L'Edge
+-- Function finance-bridge lit cette table par 'jwt_issuer' pour retrouver
+-- le JWKS a utiliser pour valider les signatures entrantes. Un immeuble
+-- peut etre 'suspended' (refus des appels finance sans le retirer du
+-- registre) ou 'offboarded' (purge prevue, lecture historique seulement).
+CREATE TABLE IF NOT EXISTS building_registry (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            text NOT NULL,
+  supabase_url    text NOT NULL UNIQUE,
+  jwt_issuer      text NOT NULL UNIQUE,
+  jwks_url        text NOT NULL,
+  status          text NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active','suspended','offboarded')),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_building_registry_issuer
+  ON building_registry(jwt_issuer);
+
+ALTER TABLE building_registry ENABLE ROW LEVEL SECURITY;
+
+-- Les residents n'ont pas besoin de voir d'autres immeubles ; la lecture
+-- via l'Edge Function passe par la cle anon + policy select_authenticated,
+-- mais on scope a un seul row a la fois (jwt_issuer match). Sans claim
+-- building_id, anon peut lister tous les registres — c'est acceptable :
+-- l'info (url + issuer) est par nature publique (on la trouve dans le
+-- DNS + les JWT emis).
+DROP POLICY IF EXISTS br_select_all ON building_registry;
+CREATE POLICY br_select_all ON building_registry
+  FOR SELECT TO anon, authenticated USING (TRUE);
+
+-- Ecriture : seul un admin authentifie via le dashboard Modulimo doit
+-- inserer un immeuble. Tant qu'on n'a pas de table admin_users formelle,
+-- on autorise l'ecriture uniquement via connexions service_role (qui
+-- bypass RLS par design). Aucun role 'authenticated' ne doit pouvoir
+-- ecrire ici.
+DROP POLICY IF EXISTS br_no_write ON building_registry;
+CREATE POLICY br_no_write ON building_registry
+  FOR ALL TO authenticated USING (FALSE) WITH CHECK (FALSE);
+
+-- ---------------------------------------------------------------------
+-- 3. clients.building_id — scoping explicite
+-- ---------------------------------------------------------------------
+-- La colonne est nullable dans un premier temps : on ne peut pas
+-- backfill automatiquement sans connaitre quel immeuble a provisionne
+-- quel client. Un script de migration par immeuble remplira cette
+-- colonne (et on basculera en NOT NULL quand tous les rows auront un
+-- building_id).
+ALTER TABLE clients
+  ADD COLUMN IF NOT EXISTS building_id uuid REFERENCES building_registry(id);
+
+CREATE INDEX IF NOT EXISTS idx_clients_building ON clients(building_id);
+
+-- Un meme cohabitat_user_id peut exister dans plusieurs immeubles
+-- (theoriquement : utilisateur qui change d'immeuble ou double compte).
+-- On contraint l'unicite au sein d'un meme immeuble seulement.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_clients_cohabitat_per_building
+  ON clients(building_id, cohabitat_user_id)
+  WHERE cohabitat_user_id IS NOT NULL AND building_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------
+-- 4. Helpers JWT lus depuis les claims injectes par l'Edge Function
+-- ---------------------------------------------------------------------
+-- L'Edge Function mint un JWT HS256 avec {building_id, client_id,
+-- cohabitat_user_id}. PostgREST valide la signature et expose les claims
+-- via auth.jwt(). Ces helpers centralisent la lecture + le cast.
+CREATE OR REPLACE FUNCTION jwt_building_id() RETURNS uuid
+LANGUAGE sql STABLE AS $$
+  SELECT NULLIF(auth.jwt() ->> 'building_id', '')::uuid
+$$;
+
+CREATE OR REPLACE FUNCTION jwt_client_id() RETURNS uuid
+LANGUAGE sql STABLE AS $$
+  SELECT NULLIF(auth.jwt() ->> 'client_id', '')::uuid
+$$;
+
+-- ---------------------------------------------------------------------
+-- 5. balances — solde principal par client (1:1)
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS balances (
+  client_id        uuid PRIMARY KEY REFERENCES clients(id) ON DELETE CASCADE,
+  building_id      uuid NOT NULL REFERENCES building_registry(id),
+  virtual_balance  numeric(12,2) NOT NULL DEFAULT 0.00,
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_balances_building ON balances(building_id);
+
+-- ---------------------------------------------------------------------
+-- 6. dependent_balances — un solde par dependant
+-- ---------------------------------------------------------------------
+-- `external_dep_id` est l'id du dependant cote CoHabitat (opaque pour la
+-- centrale : text pour ne pas contraindre le type a l'avance). Scopee
+-- par (client_id, external_dep_id) : un meme dependant ne peut exister
+-- qu'une fois par client.
+CREATE TABLE IF NOT EXISTS dependent_balances (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id        uuid NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+  building_id      uuid NOT NULL REFERENCES building_registry(id),
+  external_dep_id  text NOT NULL,
+  label            text,
+  virtual_balance  numeric(12,2) NOT NULL DEFAULT 0.00,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (client_id, external_dep_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dep_balances_client ON dependent_balances(client_id);
+CREATE INDEX IF NOT EXISTS idx_dep_balances_building ON dependent_balances(building_id);
+
+-- ---------------------------------------------------------------------
+-- 7. transactions — ledger append-only
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS transactions (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id         uuid NOT NULL REFERENCES clients(id),
+  building_id       uuid NOT NULL REFERENCES building_registry(id),
+  dependent_id      uuid REFERENCES dependent_balances(id),  -- null si solde principal
+  amount            numeric(12,2) NOT NULL,
+  balance_after     numeric(12,2) NOT NULL,
+  type              text NOT NULL CHECK (type IN (
+    'admin_credit',
+    'space_reservation',
+    'space_cancel_refund',
+    'trip_booking',
+    'trip_cancel_refund',
+    'trip_cancel_charge',
+    'trip_driver_earning',
+    'trip_driver_charge',
+    'lunch_purchase',
+    'demo'
+  )),
+  reference_id      uuid,
+  reference_type    text,
+  description       text,
+  idempotency_key   text UNIQUE,
+  created_by        uuid,  -- auth.users.id si cree via admin, sinon null
+  is_demo           boolean NOT NULL DEFAULT false,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tx_client_building
+  ON transactions(client_id, building_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_tx_building_created
+  ON transactions(building_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_tx_type ON transactions(type);
+CREATE INDEX IF NOT EXISTS idx_tx_reference
+  ON transactions(reference_type, reference_id)
+  WHERE reference_id IS NOT NULL;
+
+-- Append-only : pas d'UPDATE ni DELETE. Les corrections passent par une
+-- nouvelle ligne compensatoire (pattern ledger standard).
+CREATE OR REPLACE FUNCTION transactions_immutable()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'transactions is append-only (op=%)', TG_OP
+    USING ERRCODE = 'read_only_sql_transaction';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_transactions_no_update ON transactions;
+CREATE TRIGGER trg_transactions_no_update
+  BEFORE UPDATE ON transactions
+  FOR EACH ROW EXECUTE FUNCTION transactions_immutable();
+
+DROP TRIGGER IF EXISTS trg_transactions_no_delete ON transactions;
+CREATE TRIGGER trg_transactions_no_delete
+  BEFORE DELETE ON transactions
+  FOR EACH ROW EXECUTE FUNCTION transactions_immutable();
+
+-- ---------------------------------------------------------------------
+-- 8. RLS sur balances / dependent_balances / transactions
+-- ---------------------------------------------------------------------
+-- Les policies scopent au JWT injecte par l'Edge Function. Si le claim
+-- est absent (requete directe sans passer par finance-bridge), le WHERE
+-- est FALSE puisque jwt_client_id() retourne NULL.
+ALTER TABLE balances ENABLE ROW LEVEL SECURITY;
+ALTER TABLE dependent_balances ENABLE ROW LEVEL SECURITY;
+ALTER TABLE transactions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS bal_select_self ON balances;
+CREATE POLICY bal_select_self ON balances
+  FOR SELECT TO authenticated
+  USING (client_id = jwt_client_id() AND building_id = jwt_building_id());
+
+-- Aucune policy INSERT/UPDATE/DELETE pour authenticated : tout passe par
+-- les RPC SECURITY DEFINER (a venir dans les phases suivantes).
+
+DROP POLICY IF EXISTS depbal_select_self ON dependent_balances;
+CREATE POLICY depbal_select_self ON dependent_balances
+  FOR SELECT TO authenticated
+  USING (client_id = jwt_client_id() AND building_id = jwt_building_id());
+
+DROP POLICY IF EXISTS tx_select_self ON transactions;
+CREATE POLICY tx_select_self ON transactions
+  FOR SELECT TO authenticated
+  USING (client_id = jwt_client_id() AND building_id = jwt_building_id());
+
+-- ---------------------------------------------------------------------
+-- 9. RPC get_balance — lecture sure
+-- ---------------------------------------------------------------------
+-- SECURITY DEFINER pour bypasser la RLS cote lecture interne, mais on
+-- re-applique le filtre explicite sur jwt_client_id() + jwt_building_id()
+-- : la confiance repose sur PostgREST qui a deja valide le JWT central.
+--
+-- Contrat de retour :
+--   * si p_external_dep_id IS NULL => solde principal (balances)
+--   * sinon => solde du dependant (dependent_balances)
+--   * si aucune ligne n'existe encore => retourne 0.00 (clients non
+--     encore provisionnes n'ont pas d'erreur, affichent 0)
+CREATE OR REPLACE FUNCTION get_balance(
+  p_external_dep_id text DEFAULT NULL
+) RETURNS TABLE(
+  virtual_balance numeric,
+  source_kind     text,        -- 'main' | 'dependent' | 'missing'
+  updated_at      timestamptz
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_client_id   uuid := jwt_client_id();
+  v_building_id uuid := jwt_building_id();
+BEGIN
+  IF v_client_id IS NULL OR v_building_id IS NULL THEN
+    RAISE EXCEPTION 'missing_jwt_claims'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_external_dep_id IS NULL THEN
+    RETURN QUERY
+    SELECT b.virtual_balance, 'main'::text, b.updated_at
+      FROM balances b
+     WHERE b.client_id = v_client_id
+       AND b.building_id = v_building_id;
+    IF NOT FOUND THEN
+      RETURN QUERY SELECT 0.00::numeric, 'missing'::text, NULL::timestamptz;
+    END IF;
+  ELSE
+    RETURN QUERY
+    SELECT d.virtual_balance, 'dependent'::text, d.updated_at
+      FROM dependent_balances d
+     WHERE d.client_id = v_client_id
+       AND d.building_id = v_building_id
+       AND d.external_dep_id = p_external_dep_id;
+    IF NOT FOUND THEN
+      RETURN QUERY SELECT 0.00::numeric, 'missing'::text, NULL::timestamptz;
+    END IF;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION get_balance(text) FROM public;
+GRANT EXECUTE ON FUNCTION get_balance(text) TO authenticated;
+
+-- GRANTs cote tables : sans ces GRANT, meme avec RLS permissive, le role
+-- authenticated ne peut rien lire (Supabase n'auto-grant pas pour les
+-- tables creees via migration custom). On n'accorde QUE SELECT : tout
+-- INSERT/UPDATE/DELETE doit passer par les RPC SECURITY DEFINER.
+GRANT SELECT ON balances, dependent_balances, transactions TO authenticated;
+
+-- ---------------------------------------------------------------------
+-- 10. updated_at triggers
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION touch_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_br_updated_at ON building_registry;
+CREATE TRIGGER trg_br_updated_at BEFORE UPDATE ON building_registry
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+DROP TRIGGER IF EXISTS trg_balances_updated_at ON balances;
+CREATE TRIGGER trg_balances_updated_at BEFORE UPDATE ON balances
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+DROP TRIGGER IF EXISTS trg_depbal_updated_at ON dependent_balances;
+CREATE TRIGGER trg_depbal_updated_at BEFORE UPDATE ON dependent_balances
+  FOR EACH ROW EXECUTE FUNCTION touch_updated_at();
+
+COMMIT;
+
+-- Forcer PostgREST a recharger son schema pour exposer get_balance.
+NOTIFY pgrst, 'reload schema';
+
+-- =====================================================================
+-- Rollback (pour reference — a executer manuellement si besoin)
+-- =====================================================================
+-- BEGIN;
+-- DROP FUNCTION IF EXISTS get_balance(text);
+-- DROP TRIGGER IF EXISTS trg_transactions_no_delete ON transactions;
+-- DROP TRIGGER IF EXISTS trg_transactions_no_update ON transactions;
+-- DROP FUNCTION IF EXISTS transactions_immutable();
+-- DROP TABLE IF EXISTS transactions;
+-- DROP TABLE IF EXISTS dependent_balances;
+-- DROP TABLE IF EXISTS balances;
+-- DROP FUNCTION IF EXISTS jwt_client_id();
+-- DROP FUNCTION IF EXISTS jwt_building_id();
+-- ALTER TABLE clients DROP COLUMN IF EXISTS building_id;
+-- DROP TABLE IF EXISTS building_registry;
+-- COMMIT;

--- a/sql/008_finance_central_phase1_fix.sql
+++ b/sql/008_finance_central_phase1_fix.sql
@@ -1,0 +1,87 @@
+-- =====================================================================
+-- 008_finance_central_phase1_fix.sql
+-- Correctif Phase 1 : bascule get_balance sur le pattern service_role +
+-- parametres explicites au lieu de lire auth.jwt().
+--
+-- Contexte : le smoke test de la Phase 1 a revele que PostgREST du projet
+-- central refuse les JWT HS256 mintes par l'Edge Function (erreur
+-- PGRST301 "No suitable key or wrong key type"). Le projet central a la
+-- signature asymetrique activee, et PostgREST ne fait plus confiance aux
+-- JWT signes avec le JWT Secret HS256.
+--
+-- Plutot que d'essayer de minter avec une cle asymetrique dont on n'a
+-- pas acces en Edge Function, on adopte le pattern Supabase standard :
+--   * L'Edge Function finance-bridge valide le JWT entrant (signe par
+--     l'Auth Supabase de l'immeuble) et resout (client_id, building_id).
+--   * Elle appelle ensuite get_balance avec SERVICE_ROLE_KEY, en passant
+--     les claims resolus en parametres explicites.
+--   * La RPC est SECURITY DEFINER et ne peut etre appelee QUE par
+--     service_role (REVOKE + GRANT cible). Authenticated/anon sont
+--     refuses direct au niveau du GRANT.
+--
+-- La frontiere de confiance reste l'Edge Function : c'est elle qui
+-- garantit que p_client_id et p_building_id correspondent au JWT verifie.
+-- La RPC ne re-valide pas ; elle filtre simplement par les params.
+-- =====================================================================
+
+BEGIN;
+
+-- Ancienne signature (lisait jwt_client_id() / jwt_building_id())
+DROP FUNCTION IF EXISTS get_balance(text);
+
+CREATE OR REPLACE FUNCTION get_balance(
+  p_client_id       uuid,
+  p_building_id     uuid,
+  p_external_dep_id text DEFAULT NULL
+) RETURNS TABLE(
+  virtual_balance numeric,
+  source_kind     text,        -- 'main' | 'dependent' | 'missing'
+  updated_at      timestamptz
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF p_client_id IS NULL OR p_building_id IS NULL THEN
+    RAISE EXCEPTION 'missing_params'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  IF p_external_dep_id IS NULL THEN
+    RETURN QUERY
+    SELECT b.virtual_balance, 'main'::text, b.updated_at
+      FROM balances b
+     WHERE b.client_id = p_client_id
+       AND b.building_id = p_building_id;
+    IF NOT FOUND THEN
+      RETURN QUERY SELECT 0.00::numeric, 'missing'::text, NULL::timestamptz;
+    END IF;
+  ELSE
+    RETURN QUERY
+    SELECT d.virtual_balance, 'dependent'::text, d.updated_at
+      FROM dependent_balances d
+     WHERE d.client_id = p_client_id
+       AND d.building_id = p_building_id
+       AND d.external_dep_id = p_external_dep_id;
+    IF NOT FOUND THEN
+      RETURN QUERY SELECT 0.00::numeric, 'missing'::text, NULL::timestamptz;
+    END IF;
+  END IF;
+END;
+$$;
+
+-- Refus explicite pour public/anon/authenticated : seule l'Edge Function
+-- avec service_role a le droit d'appeler. Les residents n'atteignent
+-- cette RPC que via /functions/v1/finance-bridge/get-balance.
+REVOKE ALL ON FUNCTION get_balance(uuid, uuid, text) FROM public;
+REVOKE ALL ON FUNCTION get_balance(uuid, uuid, text) FROM anon;
+REVOKE ALL ON FUNCTION get_balance(uuid, uuid, text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION get_balance(uuid, uuid, text) TO service_role;
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';
+
+-- =====================================================================
+-- Rollback :
+--   DROP FUNCTION get_balance(uuid, uuid, text);
+--   Puis re-executer la Phase 1 pour restaurer la version avec JWT.
+-- =====================================================================

--- a/sql/009_finance_central_phase2.sql
+++ b/sql/009_finance_central_phase2.sql
@@ -25,6 +25,39 @@ BEGIN;
 -- Mirror de la table CoHabitat locale, mais scopee par building_id et
 -- liee via transaction_id au ledger. Permet la vue "achats recents par
 -- machine" sans scanner transactions pour filtrer type='lunch_purchase'.
+--
+-- Migration defensive : la centrale avait historiquement une table
+-- lunch_transactions avec un schema different (user_id a la place de
+-- client_id, pas de building_id). Cette table a ete rendue obsolete par
+-- 001_lunch_coherence.sql cote CoHabitat (qui a deplace l'audit dans la
+-- DB de l'immeuble). Si on la trouve, on la renomme pour preserver les
+-- donnees historiques sans bloquer la creation du nouveau schema.
+DO $rename_legacy$
+DECLARE
+  v_has_client_id boolean;
+  v_exists        boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name = 'lunch_transactions'
+  ) INTO v_exists;
+
+  IF v_exists THEN
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'lunch_transactions'
+         AND column_name = 'client_id'
+    ) INTO v_has_client_id;
+
+    IF NOT v_has_client_id THEN
+      -- Vieux schema central : renomme pour preserver l'historique
+      EXECUTE 'ALTER TABLE public.lunch_transactions RENAME TO lunch_transactions_legacy_central';
+      RAISE NOTICE 'lunch_transactions existait avec l''ancien schema — renomme en lunch_transactions_legacy_central';
+    END IF;
+  END IF;
+END $rename_legacy$;
+
 CREATE TABLE IF NOT EXISTS lunch_transactions (
   id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   transaction_id  uuid NOT NULL REFERENCES transactions(id),

--- a/sql/009_finance_central_phase2.sql
+++ b/sql/009_finance_central_phase2.sql
@@ -1,0 +1,296 @@
+-- =====================================================================
+-- 009_finance_central_phase2.sql
+-- Phase 2 : RPC mutants (adjust_balance primitive + lunch_purchase).
+--
+-- Pose les invariants qui rendent les mouvements de solde sur. Chaque
+-- mutation est :
+--   * atomique (lock SELECT FOR UPDATE + insert transactions dans la
+--     meme transaction PostgreSQL),
+--   * idempotente (idempotency_key unique ; un retour a la meme cle
+--     ne re-debite pas, il replay l'etat precedent),
+--   * fail-closed sur solde insuffisant (raise insufficient_funds),
+--   * append-only (les transactions ne peuvent jamais etre modifiees,
+--     trigger pose en Phase 1 toujours actif).
+--
+-- Tout est appelable uniquement par service_role. La frontiere de
+-- confiance reste l'Edge Function finance-bridge (Phase 0), qui valide
+-- le JWT entrant et passe les claims resolus en parametres explicites.
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. Table lunch_transactions (audit centrale des achats kiosk)
+-- ---------------------------------------------------------------------
+-- Mirror de la table CoHabitat locale, mais scopee par building_id et
+-- liee via transaction_id au ledger. Permet la vue "achats recents par
+-- machine" sans scanner transactions pour filtrer type='lunch_purchase'.
+CREATE TABLE IF NOT EXISTS lunch_transactions (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  transaction_id  uuid NOT NULL REFERENCES transactions(id),
+  client_id       uuid NOT NULL REFERENCES clients(id),
+  building_id     uuid NOT NULL REFERENCES building_registry(id),
+  dependent_balance_id uuid REFERENCES dependent_balances(id),
+  machine_id      text NOT NULL,
+  slot_id         text,
+  buyer_name      text,
+  price           numeric(10,2) NOT NULL CHECK (price >= 0),
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lunch_tx_client_created
+  ON lunch_transactions(client_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_lunch_tx_machine_created
+  ON lunch_transactions(machine_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_lunch_tx_building_created
+  ON lunch_transactions(building_id, created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_lunch_tx_transaction
+  ON lunch_transactions(transaction_id);
+
+ALTER TABLE lunch_transactions ENABLE ROW LEVEL SECURITY;
+
+-- Aucune policy pour authenticated/anon : pas d'acces direct. Tout
+-- passe par les RPC (service_role bypass RLS car SECURITY DEFINER).
+
+-- service_role a besoin d'acces directs pour les operations admin et
+-- pour que les RPC SECURITY DEFINER lancees depuis service_role ne
+-- rencontrent pas de permission denied lors des SELECT internes.
+-- Standard Supabase : service_role a des GRANTs larges, la securite
+-- vient de qui detient la cle (uniquement l'Edge Function).
+GRANT SELECT, INSERT ON lunch_transactions TO service_role;
+GRANT SELECT, INSERT, UPDATE ON balances TO service_role;
+GRANT SELECT, INSERT, UPDATE ON dependent_balances TO service_role;
+GRANT SELECT, INSERT ON transactions TO service_role;
+
+-- ---------------------------------------------------------------------
+-- 2. RPC adjust_balance (primitive mutation)
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION adjust_balance(
+  p_client_id         uuid,
+  p_building_id       uuid,
+  p_amount            numeric,
+  p_type              text,
+  p_dep_external_id   text DEFAULT NULL,
+  p_reference_id      uuid DEFAULT NULL,
+  p_reference_type    text DEFAULT NULL,
+  p_description       text DEFAULT NULL,
+  p_idempotency_key   text DEFAULT NULL,
+  p_created_by        uuid DEFAULT NULL,
+  p_is_demo           boolean DEFAULT false
+) RETURNS TABLE(
+  transaction_id    uuid,
+  virtual_balance   numeric,
+  dependent_id      uuid,
+  idempotent_replay boolean
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_existing_id      uuid;
+  v_existing_bal     numeric;
+  v_existing_client  uuid;
+  v_existing_bldg    uuid;
+  v_existing_dep     uuid;
+  v_current          numeric;
+  v_new              numeric;
+  v_dep_id           uuid;
+  v_tx_id            uuid;
+BEGIN
+  IF p_client_id IS NULL OR p_building_id IS NULL THEN
+    RAISE EXCEPTION 'missing_params'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  IF p_amount IS NULL OR p_amount = 0 THEN
+    RAISE EXCEPTION 'zero_amount'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Idempotency : si la cle a deja ete utilisee, retourne l'etat
+  -- precedent. Defense : la cle doit appartenir au meme (client, building)
+  -- pour prevenir qu'un JWT compromis ne lise le ledger d'un autre.
+  IF p_idempotency_key IS NOT NULL THEN
+    SELECT t.id, t.balance_after, t.client_id, t.building_id, t.dependent_id
+      INTO v_existing_id, v_existing_bal, v_existing_client, v_existing_bldg, v_existing_dep
+      FROM transactions t
+     WHERE t.idempotency_key = p_idempotency_key;
+    IF FOUND THEN
+      IF v_existing_client <> p_client_id OR v_existing_bldg <> p_building_id THEN
+        -- Cle vue sous un autre (client, building) : on refuse plutot
+        -- que de leak la balance_after d'un autre tenant.
+        RAISE EXCEPTION 'idempotency_key_collision'
+          USING ERRCODE = 'unique_violation';
+      END IF;
+      RETURN QUERY SELECT v_existing_id, v_existing_bal, v_existing_dep, true;
+      RETURN;
+    END IF;
+  END IF;
+
+  -- Verrouillage + lecture du solde courant. On cree la ligne si elle
+  -- n'existe pas pour ne pas imposer un provisioning prealable.
+  IF p_dep_external_id IS NULL THEN
+    -- Solde principal
+    INSERT INTO balances (client_id, building_id, virtual_balance)
+    VALUES (p_client_id, p_building_id, 0.00)
+    ON CONFLICT (client_id) DO NOTHING;
+
+    SELECT b.virtual_balance INTO v_current
+      FROM balances b
+     WHERE b.client_id = p_client_id AND b.building_id = p_building_id
+     FOR UPDATE;
+
+    v_dep_id := NULL;
+  ELSE
+    -- Solde d'un dependant
+    SELECT d.id, d.virtual_balance INTO v_dep_id, v_current
+      FROM dependent_balances d
+     WHERE d.client_id = p_client_id
+       AND d.building_id = p_building_id
+       AND d.external_dep_id = p_dep_external_id
+     FOR UPDATE;
+
+    IF NOT FOUND THEN
+      INSERT INTO dependent_balances (client_id, building_id, external_dep_id, virtual_balance)
+      VALUES (p_client_id, p_building_id, p_dep_external_id, 0.00)
+      RETURNING id INTO v_dep_id;
+      v_current := 0.00;
+    END IF;
+  END IF;
+
+  v_new := v_current + p_amount;
+
+  -- Fail-closed : on refuse tout mouvement qui ferait passer le solde
+  -- en negatif. Le type ne donne PAS d'exception : un 'admin_credit'
+  -- avec montant negatif doit quand meme couvrir le solde (c'est une
+  -- operation admin de correction qui ne doit pas creer de dette).
+  IF v_new < 0 THEN
+    RAISE EXCEPTION 'insufficient_funds : requested %, available %',
+      p_amount, v_current
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Applique le nouveau solde
+  IF p_dep_external_id IS NULL THEN
+    UPDATE balances SET virtual_balance = v_new
+     WHERE client_id = p_client_id AND building_id = p_building_id;
+  ELSE
+    UPDATE dependent_balances SET virtual_balance = v_new
+     WHERE id = v_dep_id;
+  END IF;
+
+  -- Ecrit la ligne ledger. Le trigger append-only de Phase 1 empeche
+  -- toute mutation ulterieure ; les corrections passent par une ligne
+  -- compensatoire (adjust_balance avec le montant inverse).
+  INSERT INTO transactions (
+    client_id, building_id, dependent_id, amount, balance_after,
+    type, reference_id, reference_type, description,
+    idempotency_key, created_by, is_demo
+  ) VALUES (
+    p_client_id, p_building_id, v_dep_id, p_amount, v_new,
+    p_type, p_reference_id, p_reference_type, p_description,
+    p_idempotency_key, p_created_by, p_is_demo
+  ) RETURNING id INTO v_tx_id;
+
+  RETURN QUERY SELECT v_tx_id, v_new, v_dep_id, false;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION adjust_balance(uuid, uuid, numeric, text, text, uuid, text, text, text, uuid, boolean) FROM public;
+REVOKE ALL ON FUNCTION adjust_balance(uuid, uuid, numeric, text, text, uuid, text, text, text, uuid, boolean) FROM authenticated, anon;
+GRANT EXECUTE ON FUNCTION adjust_balance(uuid, uuid, numeric, text, text, uuid, text, text, text, uuid, boolean) TO service_role;
+
+-- ---------------------------------------------------------------------
+-- 3. RPC lunch_purchase (wrapper metier pour le kiosk)
+-- ---------------------------------------------------------------------
+-- Fait un debit atomique + ecrit la ligne d'audit lunch_transactions.
+-- La colonne transaction_id est UNIQUE, donc si un idempotent_replay
+-- se produit on retourne la meme ligne audit qu'au premier appel.
+CREATE OR REPLACE FUNCTION lunch_purchase(
+  p_client_id         uuid,
+  p_building_id       uuid,
+  p_machine_id        text,
+  p_amount            numeric,
+  p_idempotency_key   text,
+  p_dep_external_id   text DEFAULT NULL,
+  p_slot_id           text DEFAULT NULL,
+  p_buyer_name        text DEFAULT NULL
+) RETURNS TABLE(
+  transaction_id    uuid,
+  lunch_audit_id    uuid,
+  virtual_balance   numeric,
+  idempotent_replay boolean
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_tx_id      uuid;
+  v_bal        numeric;
+  v_dep_id     uuid;
+  v_replay     boolean;
+  v_audit_id   uuid;
+BEGIN
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'invalid_amount : lunch_purchase requires positive amount'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  IF p_machine_id IS NULL OR p_machine_id = '' THEN
+    RAISE EXCEPTION 'missing_machine_id'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Debit atomique via la primitive
+  SELECT t.transaction_id, t.virtual_balance, t.dependent_id, t.idempotent_replay
+    INTO v_tx_id, v_bal, v_dep_id, v_replay
+    FROM adjust_balance(
+      p_client_id       => p_client_id,
+      p_building_id     => p_building_id,
+      p_amount          => -p_amount,
+      p_type            => 'lunch_purchase',
+      p_dep_external_id => p_dep_external_id,
+      p_reference_type  => 'lunch_transaction',
+      p_description     => 'Lunch machine ' || p_machine_id
+                           || CASE WHEN p_buyer_name IS NOT NULL AND p_buyer_name <> ''
+                                   THEN ' : ' || p_buyer_name ELSE '' END,
+      p_idempotency_key => p_idempotency_key
+    ) t;
+
+  -- Audit : si replay, on retrouve la ligne existante liee par
+  -- transaction_id (UNIQUE). Sinon on insere. Le INSERT peut faillir
+  -- si (par race) deux appels concurrents arrivent avec la meme cle
+  -- idempotent — mais adjust_balance serialize deja via le SELECT FOR
+  -- UPDATE, donc impossible en pratique.
+  IF v_replay THEN
+    SELECT lt.id INTO v_audit_id
+      FROM lunch_transactions lt
+     WHERE lt.transaction_id = v_tx_id;
+  ELSE
+    INSERT INTO lunch_transactions AS lt (
+      transaction_id, client_id, building_id, dependent_balance_id,
+      machine_id, slot_id, buyer_name, price
+    ) VALUES (
+      v_tx_id, p_client_id, p_building_id, v_dep_id,
+      p_machine_id, p_slot_id, p_buyer_name, p_amount
+    ) RETURNING lt.id INTO v_audit_id;
+
+    -- Lie le ledger a l'audit (champ reference_id) pour la tracabilite
+    -- complete. On utilise un UPDATE direct, exceptionnel car
+    -- transactions est append-only : on le permet juste pour remplir
+    -- une FK de corroboration, pas pour changer la semantique. On
+    -- bypasse le trigger en desactivant temporairement.
+    --
+    -- Alternative cleanup : ne PAS remplir reference_id pour lunch,
+    -- l'audit lunch_transactions est deja la source de verite via
+    -- transaction_id. C'est ce qu'on fait : plus simple, pas de
+    -- contournement du trigger.
+  END IF;
+
+  RETURN QUERY SELECT v_tx_id, v_audit_id, v_bal, v_replay;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION lunch_purchase(uuid, uuid, text, numeric, text, text, text, text) FROM public;
+REVOKE ALL ON FUNCTION lunch_purchase(uuid, uuid, text, numeric, text, text, text, text) FROM authenticated, anon;
+GRANT EXECUTE ON FUNCTION lunch_purchase(uuid, uuid, text, numeric, text, text, text, text) TO service_role;
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/functions/finance-bridge/README.md
+++ b/supabase/functions/finance-bridge/README.md
@@ -1,0 +1,135 @@
+# finance-bridge — passerelle finance Modulimo (Phase 0)
+
+Edge Function qui valide un JWT signé par l'Auth Supabase d'un immeuble
+CoHabitat, résout le `cohabitat_user_id` en `client_id` + `building_id` via
+la base centrale, et ré-émet un JWT court-terme pour appeler les RPC
+financières centrales.
+
+Voir la spec complète de la Phase 0 dans le ticket de migration (solde
+central). Ce README couvre uniquement le déploiement et le test.
+
+## Statut
+
+- **Phase 0** : `/get-balance` stub retourne `virtual_balance: 0.00`.
+  L'objectif est de prouver le chemin d'auth bout-en-bout.
+- **Phase 1+** : branche les RPC centrales réelles (`get_balance`,
+  `list_transactions`, etc.).
+
+## Pré-requis côté base centrale
+
+La migration `building_registry` + `clients.building_id` doit être
+déployée avant que cette fonction serve du trafic réel (Phase 0 step 1).
+
+Chaque immeuble inscrit doit exposer un JWKS ES256/RS256 — Supabase Auth
+doit être configuré avec une clé asymétrique (sinon on ne peut pas
+valider la signature sans détenir leur secret, ce qui casserait
+l'isolation).
+
+## Structure
+
+```
+finance-bridge/
+├── index.ts               Handler HTTP + routing des endpoints
+├── lib/
+│   ├── types.ts           Types partagés (pas de dépendance)
+│   ├── resolve.ts         JWT -> claims centrales (pure, adapters injectés)
+│   ├── jwt.ts             Mint du JWT central (HS256)
+│   ├── registry.ts        Adapters prod (PostgREST + JWKS distant)
+│   └── logger.ts          Log JSON structuré
+├── handlers/
+│   └── get_balance.ts     Endpoint pilote
+├── tests/
+│   ├── fixtures.ts        Keypairs ES256 in-memory + adapters fakes
+│   ├── cross_tenant_test.ts   Tests de fuite inter-immeuble (CI gate)
+│   ├── resolve_test.ts    Edge cases du parser JWT
+│   └── jwt_test.ts        Mint + verify roundtrip
+└── deno.jsonc             Tasks + fmt + lint
+```
+
+## Déploiement
+
+```sh
+supabase functions deploy finance-bridge --project-ref bpxscgrbxjscicpnheep
+```
+
+Variables d'environnement (toutes sauf `SUPABASE_JWT_SECRET` sont
+pré-injectées par Supabase) :
+
+| Variable | Role |
+|---|---|
+| `SUPABASE_URL` | URL du projet central |
+| `SUPABASE_ANON_KEY` | Lecture `building_registry` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Lecture `clients` (bypass RLS) |
+| `SUPABASE_JWT_SECRET` | Signe le JWT central émis vers PostgREST |
+
+`SUPABASE_JWT_SECRET` est le secret HS256 du projet central ; il ne
+quitte jamais cette fonction.
+
+## Appel côté client
+
+```js
+const { data, error } = await sb.functions.invoke('finance-bridge/get-balance', {
+  body: { dependent_id: null },
+});
+```
+
+Réponse (Phase 0) :
+```json
+{
+  "client_id": "...",
+  "building_id": "...",
+  "dependent_id": null,
+  "virtual_balance": 0.00,
+  "source": "central"
+}
+```
+
+## Tests locaux
+
+```sh
+cd supabase/functions/finance-bridge
+deno task test
+```
+
+Les tests n'ont **aucune** dépendance réseau : les JWKS, les JWT et la
+base centrale sont tous simulés en mémoire.
+
+### Tests critiques en CI
+
+`tests/cross_tenant_test.ts` doit rester vert à tout prix — c'est le
+garde-fou qui empêche une régression de laisser l'immeuble A lire les
+données de l'immeuble B. Scénarios couverts :
+
+1. JWT de A avec `iss` réécrit vers B → `INVALID_SIGNATURE`
+2. JWT forgé avec la mauvaise clé privée → `INVALID_SIGNATURE`
+3. JWT valide mais body réclame `client_id` d'un autre → `CLIENT_ID_MISMATCH`
+4. `iss` inconnu du registry → `UNKNOWN_ISSUER`
+5. Immeuble suspendu → `BUILDING_INACTIVE`
+6. `cohabitat_user_id` sans `clients` → `CLIENT_NOT_FOUND`
+7. JWT expiré → rejet par `jose`
+8. Audience incorrecte → rejet par `jose`
+9. Même `cohabitat_user_id` existe dans deux immeubles → lookup par
+   `(cohabitat_user_id, building_id)` composé, pas par user seul
+
+## Ajout d'un nouvel immeuble au registre
+
+Opération manuelle, effectuée par un admin Modulimo (pas de RPC publique) :
+
+```sql
+INSERT INTO building_registry (name, supabase_url, jwt_issuer, jwks_url, status)
+VALUES (
+  'Pointe Est',
+  'https://uwyhrdjlwetcbtskijrs.supabase.co',
+  'https://uwyhrdjlwetcbtskijrs.supabase.co/auth/v1',
+  'https://uwyhrdjlwetcbtskijrs.supabase.co/auth/v1/.well-known/jwks.json',
+  'active'
+);
+```
+
+Puis backfiller `clients.building_id` pour les résidents de cet immeuble.
+
+## Prochaine étape
+
+Phase 1 : écrire la migration SQL `building_registry` + `clients.building_id`
++ les RPC `get_balance` et `list_transactions`, puis brancher
+`handlers/get_balance.ts` dessus.

--- a/supabase/functions/finance-bridge/README.md
+++ b/supabase/functions/finance-bridge/README.md
@@ -10,15 +10,20 @@ central). Ce README couvre uniquement le déploiement et le test.
 
 ## Statut
 
-- **Phase 0** : `/get-balance` stub retourne `virtual_balance: 0.00`.
-  L'objectif est de prouver le chemin d'auth bout-en-bout.
-- **Phase 1+** : branche les RPC centrales réelles (`get_balance`,
-  `list_transactions`, etc.).
+- **Phase 0** ✅ squelette d'auth + 9 scénarios de fuite en CI.
+- **Phase 1** ✅ migration SQL `sql/007_finance_central_phase1.sql` +
+  `/get-balance` branché sur la RPC centrale `get_balance`. Renvoie
+  `{ virtual_balance, source_kind, updated_at }` ; `source_kind='missing'`
+  signifie que le client n'a pas encore de row `balances` (traité comme 0).
+- **Phase 2+** : RPC mutants (`lunch_purchase`, `adjust_balance`,
+  `trip_book_network`, `record_real_payment`) à ajouter.
 
 ## Pré-requis côté base centrale
 
-La migration `building_registry` + `clients.building_id` doit être
-déployée avant que cette fonction serve du trafic réel (Phase 0 step 1).
+Déployer `sql/007_finance_central_phase1.sql` avant d'activer la
+fonction : elle crée `building_registry`, `clients.building_id`,
+`balances`, `dependent_balances`, `transactions`, et la RPC
+`get_balance`.
 
 Chaque immeuble inscrit doit exposer un JWKS ES256/RS256 — Supabase Auth
 doit être configuré avec une clé asymétrique (sinon on ne peut pas
@@ -73,16 +78,22 @@ const { data, error } = await sb.functions.invoke('finance-bridge/get-balance', 
 });
 ```
 
-Réponse (Phase 0) :
+Réponse :
 ```json
 {
   "client_id": "...",
   "building_id": "...",
   "dependent_id": null,
-  "virtual_balance": 0.00,
-  "source": "central"
+  "virtual_balance": 42.00,
+  "source": "central",
+  "source_kind": "main",
+  "updated_at": "2026-04-20T10:00:00Z"
 }
 ```
+
+`source_kind` vaut `main` (solde principal), `dependent` (solde d'un
+dépendant identifié par `dependent_id`), ou `missing` (pas encore
+provisionné → `virtual_balance = 0.00`).
 
 ## Tests locaux
 
@@ -130,6 +141,13 @@ Puis backfiller `clients.building_id` pour les résidents de cet immeuble.
 
 ## Prochaine étape
 
-Phase 1 : écrire la migration SQL `building_registry` + `clients.building_id`
-+ les RPC `get_balance` et `list_transactions`, puis brancher
-`handlers/get_balance.ts` dessus.
+Phase 2 : RPC mutants côté central.
+1. `adjust_balance(p_amount, p_type, p_reference, p_idem_key)` — mouvement
+   atomique avec idempotency key, update `balances` + insert `transactions`.
+2. `lunch_purchase(p_machine_id, p_slot_id, p_amount, p_dep_id, p_idem_key)`
+   — remplace la RPC locale CoHabitat, gère le fail-closed si solde
+   insuffisant.
+3. `record_real_payment(p_client_id, p_amount_real, p_amount_virtual,
+   p_method)` — crédit admin, lie une entrée `real_payments` à une ligne
+   `transactions`.
+4. Dual-write depuis CoHabitat pendant la phase de bascule.

--- a/supabase/functions/finance-bridge/README.md
+++ b/supabase/functions/finance-bridge/README.md
@@ -62,13 +62,13 @@ pré-injectées par Supabase) :
 
 | Variable | Role |
 |---|---|
-| `SUPABASE_URL` | URL du projet central |
-| `SUPABASE_ANON_KEY` | Lecture `building_registry` |
-| `SUPABASE_SERVICE_ROLE_KEY` | Lecture `clients` (bypass RLS) |
-| `SUPABASE_JWT_SECRET` | Signe le JWT central émis vers PostgREST |
+| `SUPABASE_URL` | URL du projet central (auto-injectée) |
+| `SUPABASE_ANON_KEY` | Lecture `building_registry` (auto-injectée) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Lecture `clients` (auto-injectée, bypass RLS) |
+| `FINANCE_JWT_SECRET` | Signe le JWT central émis vers PostgREST. À définir manuellement : `supabase secrets set FINANCE_JWT_SECRET=...` (la valeur = JWT Secret du dashboard Supabase → API) |
 
-`SUPABASE_JWT_SECRET` est le secret HS256 du projet central ; il ne
-quitte jamais cette fonction.
+Le nom `FINANCE_JWT_SECRET` évite la collision avec le préfixe `SUPABASE_*`
+réservé par la CLI.
 
 ## Appel côté client
 

--- a/supabase/functions/finance-bridge/deno.jsonc
+++ b/supabase/functions/finance-bridge/deno.jsonc
@@ -1,0 +1,18 @@
+{
+  // Tasks locaux pour le developpement. En prod, Supabase ignore ce fichier
+  // et lance directement index.ts.
+  "tasks": {
+    "test": "deno test --allow-env --allow-net --no-check=remote tests/ lib/"
+  },
+  "lint": {
+    "rules": {
+      "tags": ["recommended"]
+    }
+  },
+  "fmt": {
+    "lineWidth": 100,
+    "indentWidth": 2,
+    "semiColons": true,
+    "singleQuote": true
+  }
+}

--- a/supabase/functions/finance-bridge/deno.lock
+++ b/supabase/functions/finance-bridge/deno.lock
@@ -1,0 +1,11 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:jose@5": "5.10.0"
+  },
+  "npm": {
+    "jose@5.10.0": {
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="
+    }
+  }
+}

--- a/supabase/functions/finance-bridge/handlers/get_balance.ts
+++ b/supabase/functions/finance-bridge/handlers/get_balance.ts
@@ -1,0 +1,40 @@
+// Endpoint pilote : POST /finance-bridge/get-balance
+// But de la Phase 0 : prouver que l'aller-retour JWT fonctionne de bout
+// en bout. La RPC central `get_balance` n'existe pas encore — on retourne
+// 0.00 en attendant la Phase 1.
+
+import type { ResolvedClaims } from '../lib/types.ts';
+
+export interface GetBalanceRequest {
+  // Optionnel : verification defensive — le body ne peut pas reclamer un
+  // client_id different de celui que le JWT a prouve.
+  client_id?: string;
+  dependent_id?: string | null;
+}
+
+export interface GetBalanceResponse {
+  client_id: string;
+  building_id: string;
+  dependent_id: string | null;
+  virtual_balance: number;  // stub Phase 0
+  source: 'central';
+}
+
+export function handleGetBalance(
+  claims: ResolvedClaims,
+  body: GetBalanceRequest | null,
+): { status: number; body: GetBalanceResponse | { error: string } } {
+  if (body && body.client_id && body.client_id !== claims.client_id) {
+    return { status: 403, body: { error: 'CLIENT_ID_MISMATCH' } };
+  }
+  return {
+    status: 200,
+    body: {
+      client_id: claims.client_id,
+      building_id: claims.building_id,
+      dependent_id: body?.dependent_id ?? null,
+      virtual_balance: 0.00,
+      source: 'central',
+    },
+  };
+}

--- a/supabase/functions/finance-bridge/handlers/get_balance.ts
+++ b/supabase/functions/finance-bridge/handlers/get_balance.ts
@@ -1,40 +1,73 @@
-// Endpoint pilote : POST /finance-bridge/get-balance
-// But de la Phase 0 : prouver que l'aller-retour JWT fonctionne de bout
-// en bout. La RPC central `get_balance` n'existe pas encore — on retourne
-// 0.00 en attendant la Phase 1.
+// Endpoint /get-balance : appelle la RPC centrale get_balance avec un JWT
+// re-mint. Le body client reclame optionnellement un dependent_id ; on
+// verifie qu'il ne reclame pas un client_id different du JWT.
 
 import type { ResolvedClaims } from '../lib/types.ts';
+import type { CentralCaller } from '../lib/central.ts';
 
 export interface GetBalanceRequest {
-  // Optionnel : verification defensive — le body ne peut pas reclamer un
-  // client_id different de celui que le JWT a prouve.
-  client_id?: string;
+  client_id?: string;        // optionnel, verifie == claims.client_id
   dependent_id?: string | null;
+}
+
+// Retour de la RPC PostgREST (table function => array de rows).
+interface RpcRow {
+  virtual_balance: number;
+  source_kind: 'main' | 'dependent' | 'missing';
+  updated_at: string | null;
 }
 
 export interface GetBalanceResponse {
   client_id: string;
   building_id: string;
   dependent_id: string | null;
-  virtual_balance: number;  // stub Phase 0
+  virtual_balance: number;
   source: 'central';
+  source_kind: 'main' | 'dependent' | 'missing';
+  updated_at: string | null;
 }
 
-export function handleGetBalance(
+export async function handleGetBalance(
   claims: ResolvedClaims,
   body: GetBalanceRequest | null,
-): { status: number; body: GetBalanceResponse | { error: string } } {
+  caller: CentralCaller,
+  centralJwt: string,
+): Promise<{ status: number; body: GetBalanceResponse | { error: string; detail?: unknown } }> {
   if (body && body.client_id && body.client_id !== claims.client_id) {
     return { status: 403, body: { error: 'CLIENT_ID_MISMATCH' } };
   }
+
+  const depId = body?.dependent_id ?? null;
+  const res = await caller.callRpc<RpcRow[]>(
+    'get_balance',
+    { p_external_dep_id: depId },
+    centralJwt,
+  );
+
+  if (!res.ok) {
+    return {
+      status: res.status === 401 || res.status === 403 ? res.status : 502,
+      body: { error: 'CENTRAL_RPC_FAILED', detail: res.body },
+    };
+  }
+
+  // PostgREST retourne un tableau pour les table-functions. Notre RPC
+  // garantit toujours au moins un row (row 'missing' si pas de solde).
+  const row = Array.isArray(res.data) ? res.data[0] : null;
+  if (!row) {
+    return { status: 502, body: { error: 'CENTRAL_RPC_EMPTY' } };
+  }
+
   return {
     status: 200,
     body: {
       client_id: claims.client_id,
       building_id: claims.building_id,
-      dependent_id: body?.dependent_id ?? null,
-      virtual_balance: 0.00,
+      dependent_id: depId,
+      virtual_balance: Number(row.virtual_balance),
       source: 'central',
+      source_kind: row.source_kind,
+      updated_at: row.updated_at,
     },
   };
 }

--- a/supabase/functions/finance-bridge/handlers/get_balance.ts
+++ b/supabase/functions/finance-bridge/handlers/get_balance.ts
@@ -40,7 +40,11 @@ export async function handleGetBalance(
   const depId = body?.dependent_id ?? null;
   const res = await caller.callRpc<RpcRow[]>(
     'get_balance',
-    { p_external_dep_id: depId },
+    {
+      p_client_id: claims.client_id,
+      p_building_id: claims.building_id,
+      p_external_dep_id: depId,
+    },
     centralJwt,
   );
 

--- a/supabase/functions/finance-bridge/handlers/lunch_purchase.ts
+++ b/supabase/functions/finance-bridge/handlers/lunch_purchase.ts
@@ -1,0 +1,111 @@
+// Endpoint POST /lunch-purchase : debit atomique pour un achat kiosk.
+// Le client (kiosque) fournit un idempotency_key stable pour chaque
+// tentative d'achat ; les retries avec la meme cle ne re-debitent pas.
+
+import type { ResolvedClaims } from '../lib/types.ts';
+import type { CentralCaller } from '../lib/central.ts';
+
+export interface LunchPurchaseRequest {
+  client_id?: string;            // optionnel, doit matcher claims.client_id
+  machine_id: string;
+  amount: number;                // toujours positif ; la RPC convertit en debit
+  idempotency_key: string;       // requis ; unique par tentative d'achat
+  dependent_id?: string | null;  // external_dep_id dans la terminologie RPC
+  slot_id?: string | null;
+  buyer_name?: string | null;
+}
+
+interface RpcRow {
+  transaction_id: string;
+  lunch_audit_id: string;
+  virtual_balance: number | string;
+  idempotent_replay: boolean;
+}
+
+export interface LunchPurchaseResponse {
+  client_id: string;
+  building_id: string;
+  transaction_id: string;
+  lunch_audit_id: string;
+  virtual_balance: number;
+  idempotent_replay: boolean;
+}
+
+export async function handleLunchPurchase(
+  claims: ResolvedClaims,
+  body: LunchPurchaseRequest | null,
+  caller: CentralCaller,
+  serviceRole: string,
+): Promise<{
+  status: number;
+  body: LunchPurchaseResponse | { error: string; detail?: unknown };
+}> {
+  if (!body) {
+    return { status: 400, body: { error: 'MISSING_BODY' } };
+  }
+  if (body.client_id && body.client_id !== claims.client_id) {
+    return { status: 403, body: { error: 'CLIENT_ID_MISMATCH' } };
+  }
+  if (!body.machine_id || typeof body.machine_id !== 'string') {
+    return { status: 400, body: { error: 'MISSING_MACHINE_ID' } };
+  }
+  if (typeof body.amount !== 'number' || !Number.isFinite(body.amount) || body.amount <= 0) {
+    return { status: 400, body: { error: 'INVALID_AMOUNT' } };
+  }
+  if (!body.idempotency_key || typeof body.idempotency_key !== 'string') {
+    return { status: 400, body: { error: 'MISSING_IDEMPOTENCY_KEY' } };
+  }
+
+  const res = await caller.callRpc<RpcRow[]>(
+    'lunch_purchase',
+    {
+      p_client_id: claims.client_id,
+      p_building_id: claims.building_id,
+      p_machine_id: body.machine_id,
+      p_amount: body.amount,
+      p_idempotency_key: body.idempotency_key,
+      p_dep_external_id: body.dependent_id ?? null,
+      p_slot_id: body.slot_id ?? null,
+      p_buyer_name: body.buyer_name ?? null,
+    },
+    serviceRole,
+  );
+
+  if (!res.ok) {
+    // Mapping des erreurs metier :
+    //   insufficient_funds  (SQLSTATE 23514)     -> 402 Payment Required
+    //   invalid_parameter   (SQLSTATE 22023)     -> 400
+    //   unique_violation    (SQLSTATE 23505, idempotency_key_collision) -> 409
+    //   autre               -> 502
+    const detail = res.body as { code?: string; message?: string } | undefined;
+    const code = detail?.code;
+    const msg = detail?.message ?? '';
+    if (code === '23514' || msg.includes('insufficient_funds')) {
+      return { status: 402, body: { error: 'INSUFFICIENT_FUNDS', detail: res.body } };
+    }
+    if (code === '22023') {
+      return { status: 400, body: { error: 'INVALID_PARAMETER', detail: res.body } };
+    }
+    if (code === '23505') {
+      return { status: 409, body: { error: 'IDEMPOTENCY_KEY_COLLISION', detail: res.body } };
+    }
+    return { status: 502, body: { error: 'CENTRAL_RPC_FAILED', detail: res.body } };
+  }
+
+  const row = Array.isArray(res.data) ? res.data[0] : null;
+  if (!row) {
+    return { status: 502, body: { error: 'CENTRAL_RPC_EMPTY' } };
+  }
+
+  return {
+    status: 200,
+    body: {
+      client_id: claims.client_id,
+      building_id: claims.building_id,
+      transaction_id: row.transaction_id,
+      lunch_audit_id: row.lunch_audit_id,
+      virtual_balance: Number(row.virtual_balance),
+      idempotent_replay: row.idempotent_replay,
+    },
+  };
+}

--- a/supabase/functions/finance-bridge/index.ts
+++ b/supabase/functions/finance-bridge/index.ts
@@ -26,6 +26,7 @@ import {
   makeFindBuildingByIssuer,
   makeFindClient,
 } from './lib/registry.ts';
+import { makePostgrestCaller } from './lib/central.ts';
 import { handleGetBalance } from './handlers/get_balance.ts';
 import { log, requestId } from './lib/logger.ts';
 
@@ -52,6 +53,8 @@ const deps = {
   findClient: makeFindClient(CENTRAL_URL, SERVICE_ROLE),
   getKeyResolver: jwksResolverFor,
 };
+
+const caller = makePostgrestCaller(CENTRAL_URL, ANON_KEY);
 
 // Liste blanche des endpoints exposes. Toute route inconnue retourne 404.
 type EndpointName = 'get-balance';
@@ -96,19 +99,23 @@ Deno.serve(async (req) => {
     }
   }
 
-  // Mint du JWT central — utilise par les handlers Phase 1+ pour parler a
-  // PostgREST. En Phase 0 on le mint quand meme pour prouver que le chemin
-  // marche bout en bout et pour pousser les tests sur ce cote.
+  // Mint du JWT central utilise par PostgREST pour valider les claims.
   const centralJwt = await mintCentralJwt(resolved.claims, { secret: secretFromEnv() });
 
   switch (endpoint) {
     case 'get-balance': {
-      const result = handleGetBalance(resolved.claims, body as never);
-      log('info', 'get_balance_ok', {
+      const result = await handleGetBalance(
+        resolved.claims,
+        body as never,
+        caller,
+        centralJwt,
+      );
+      log('info', 'get_balance_done', {
         rid,
+        endpoint,
+        status: result.status,
         building_id: resolved.claims.building_id,
         client_id: resolved.claims.client_id,
-        minted_jwt_len: centralJwt.length,
       });
       return json(result.body, result.status);
     }

--- a/supabase/functions/finance-bridge/index.ts
+++ b/supabase/functions/finance-bridge/index.ts
@@ -48,7 +48,28 @@ function json(body: unknown, status = 200) {
 
 const CENTRAL_URL = Deno.env.get('SUPABASE_URL') ?? '';
 const ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
-const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+// Supabase est cense auto-injecter SUPABASE_SERVICE_ROLE_KEY mais en
+// pratique le comportement varie selon la version du runtime + l'usage
+// de --no-verify-jwt. On accepte un fallback explicite via
+// FINANCE_SERVICE_ROLE_KEY (a definir via supabase secrets set si besoin).
+const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+  || Deno.env.get('FINANCE_SERVICE_ROLE_KEY')
+  || '';
+
+// Log de diagnostic au boot : on affiche la LONGUEUR des variables (pas
+// leur valeur) pour detecter un SERVICE_ROLE vide sans jamais logger la
+// cle elle-meme.
+log('info', 'finance_bridge_boot', {
+  has_url: CENTRAL_URL.length > 0,
+  url_host: CENTRAL_URL ? new URL(CENTRAL_URL).host : null,
+  anon_len: ANON_KEY.length,
+  service_role_len: SERVICE_ROLE.length,
+  service_role_source: Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+    ? 'auto'
+    : Deno.env.get('FINANCE_SERVICE_ROLE_KEY')
+      ? 'secret'
+      : 'missing',
+});
 
 const deps = {
   findBuildingByIssuer: makeFindBuildingByIssuer(CENTRAL_URL, ANON_KEY),
@@ -103,6 +124,15 @@ Deno.serve(async (req) => {
     } catch {
       return json({ error: 'INVALID_JSON', rid }, 400);
     }
+  }
+
+  if (!SERVICE_ROLE) {
+    log('error', 'service_role_missing', { rid });
+    return json({
+      error: 'SERVICE_ROLE_MISSING',
+      rid,
+      hint: 'set supabase secrets set FINANCE_SERVICE_ROLE_KEY=<service_role_key>',
+    }, 500);
   }
 
   switch (endpoint) {

--- a/supabase/functions/finance-bridge/index.ts
+++ b/supabase/functions/finance-bridge/index.ts
@@ -16,7 +16,11 @@
 //   SUPABASE_URL               Central project URL (preset par Supabase)
 //   SUPABASE_ANON_KEY          Lecture building_registry (preset par Supabase)
 //   SUPABASE_SERVICE_ROLE_KEY  Lecture clients (preset par Supabase)
-//   SUPABASE_JWT_SECRET        Pour minter le JWT central (preset par Supabase)
+//   FINANCE_JWT_SECRET         Secret HS256 de la centrale pour minter
+//                              le JWT passe a PostgREST. A definir via :
+//                                supabase secrets set FINANCE_JWT_SECRET=...
+//                              (la valeur est le JWT Secret du dashboard
+//                              Supabase -> Project Settings -> API)
 // -----------------------------------------------------------------------
 
 import { resolveClaims } from './lib/resolve.ts';

--- a/supabase/functions/finance-bridge/index.ts
+++ b/supabase/functions/finance-bridge/index.ts
@@ -1,0 +1,116 @@
+// Passerelle finance Modulimo — point d'entree HTTP.
+// -----------------------------------------------------------------------
+// Role : recevoir un JWT signe par l'Auth Supabase d'un immeuble CoHabitat,
+// le valider contre la JWKS de cet immeuble, resoudre le cohabitat_user_id
+// en client_id + building_id via la base centrale, puis appeler la RPC
+// financiere centrale correspondante avec un JWT re-mint court.
+//
+// Phase 0 : seul /get-balance est branche, en stub (retourne 0.00).
+// Phase 1+ : on ajoutera /list-transactions, /lunch-purchase, etc.
+//
+// Deploiement :
+//   supabase functions deploy finance-bridge --project-ref bpxscgrbxjscicpnheep
+//   supabase secrets set SUPABASE_JWT_SECRET=...  --project-ref bpxscgrbxjscicpnheep
+//
+// Variables env requises :
+//   SUPABASE_URL               Central project URL (preset par Supabase)
+//   SUPABASE_ANON_KEY          Lecture building_registry (preset par Supabase)
+//   SUPABASE_SERVICE_ROLE_KEY  Lecture clients (preset par Supabase)
+//   SUPABASE_JWT_SECRET        Pour minter le JWT central (preset par Supabase)
+// -----------------------------------------------------------------------
+
+import { resolveClaims } from './lib/resolve.ts';
+import { mintCentralJwt, secretFromEnv } from './lib/jwt.ts';
+import {
+  jwksResolverFor,
+  makeFindBuildingByIssuer,
+  makeFindClient,
+} from './lib/registry.ts';
+import { handleGetBalance } from './handlers/get_balance.ts';
+import { log, requestId } from './lib/logger.ts';
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, content-type, apikey, x-client-info, idempotency-key',
+  'Access-Control-Max-Age': '86400',
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, 'content-type': 'application/json' },
+  });
+}
+
+const CENTRAL_URL = Deno.env.get('SUPABASE_URL') ?? '';
+const ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+const deps = {
+  findBuildingByIssuer: makeFindBuildingByIssuer(CENTRAL_URL, ANON_KEY),
+  findClient: makeFindClient(CENTRAL_URL, SERVICE_ROLE),
+  getKeyResolver: jwksResolverFor,
+};
+
+// Liste blanche des endpoints exposes. Toute route inconnue retourne 404.
+type EndpointName = 'get-balance';
+const ENDPOINTS: Record<EndpointName, true> = { 'get-balance': true };
+
+function extractEndpoint(pathname: string): EndpointName | null {
+  const parts = pathname.split('/').filter(Boolean);
+  // Supabase route: /finance-bridge/<endpoint>
+  const last = parts[parts.length - 1];
+  return last && last in ENDPOINTS ? (last as EndpointName) : null;
+}
+
+Deno.serve(async (req) => {
+  const rid = requestId();
+  if (req.method === 'OPTIONS') return new Response(null, { headers: CORS_HEADERS });
+  if (req.method !== 'POST') return json({ error: 'METHOD_NOT_ALLOWED', rid }, 405);
+
+  const url = new URL(req.url);
+  const endpoint = extractEndpoint(url.pathname);
+  if (!endpoint) return json({ error: 'UNKNOWN_ENDPOINT', rid }, 404);
+
+  const auth = req.headers.get('authorization') ?? '';
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  if (!m) return json({ error: 'MISSING_BEARER', rid }, 401);
+  const token = m[1];
+
+  const resolved = await resolveClaims(token, deps);
+  if (!resolved.ok) {
+    log(resolved.error === 'INVALID_SIGNATURE' ? 'warn' : 'info', 'resolve_failed', {
+      rid, endpoint, error: resolved.error,
+    });
+    return json({ error: resolved.error, rid }, resolved.status);
+  }
+
+  let body: unknown = null;
+  const ct = req.headers.get('content-type') ?? '';
+  if (ct.includes('application/json')) {
+    try {
+      body = await req.json();
+    } catch {
+      return json({ error: 'INVALID_JSON', rid }, 400);
+    }
+  }
+
+  // Mint du JWT central — utilise par les handlers Phase 1+ pour parler a
+  // PostgREST. En Phase 0 on le mint quand meme pour prouver que le chemin
+  // marche bout en bout et pour pousser les tests sur ce cote.
+  const centralJwt = await mintCentralJwt(resolved.claims, { secret: secretFromEnv() });
+
+  switch (endpoint) {
+    case 'get-balance': {
+      const result = handleGetBalance(resolved.claims, body as never);
+      log('info', 'get_balance_ok', {
+        rid,
+        building_id: resolved.claims.building_id,
+        client_id: resolved.claims.client_id,
+        minted_jwt_len: centralJwt.length,
+      });
+      return json(result.body, result.status);
+    }
+  }
+});

--- a/supabase/functions/finance-bridge/index.ts
+++ b/supabase/functions/finance-bridge/index.ts
@@ -30,6 +30,7 @@ import {
 } from './lib/registry.ts';
 import { makePostgrestCaller } from './lib/central.ts';
 import { handleGetBalance } from './handlers/get_balance.ts';
+import { handleLunchPurchase } from './handlers/lunch_purchase.ts';
 import { log, requestId } from './lib/logger.ts';
 
 const CORS_HEADERS: Record<string, string> = {
@@ -87,8 +88,11 @@ const deps = {
 const caller = makePostgrestCaller(CENTRAL_URL, ANON_KEY);
 
 // Liste blanche des endpoints exposes. Toute route inconnue retourne 404.
-type EndpointName = 'get-balance';
-const ENDPOINTS: Record<EndpointName, true> = { 'get-balance': true };
+type EndpointName = 'get-balance' | 'lunch-purchase';
+const ENDPOINTS: Record<EndpointName, true> = {
+  'get-balance': true,
+  'lunch-purchase': true,
+};
 
 function extractEndpoint(pathname: string): EndpointName | null {
   const parts = pathname.split('/').filter(Boolean);
@@ -152,6 +156,23 @@ Deno.serve(async (req) => {
         status: result.status,
         building_id: resolved.claims.building_id,
         client_id: resolved.claims.client_id,
+      });
+      return json(result.body, result.status);
+    }
+    case 'lunch-purchase': {
+      const result = await handleLunchPurchase(
+        resolved.claims,
+        body as never,
+        caller,
+        SERVICE_ROLE,
+      );
+      log(result.status >= 500 ? 'error' : 'info', 'lunch_purchase_done', {
+        rid,
+        endpoint,
+        status: result.status,
+        building_id: resolved.claims.building_id,
+        client_id: resolved.claims.client_id,
+        replay: (result.body as { idempotent_replay?: boolean }).idempotent_replay,
       });
       return json(result.body, result.status);
     }

--- a/supabase/functions/finance-bridge/index.ts
+++ b/supabase/functions/finance-bridge/index.ts
@@ -48,27 +48,30 @@ function json(body: unknown, status = 200) {
 
 const CENTRAL_URL = Deno.env.get('SUPABASE_URL') ?? '';
 const ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
-// Supabase est cense auto-injecter SUPABASE_SERVICE_ROLE_KEY mais en
-// pratique le comportement varie selon la version du runtime + l'usage
-// de --no-verify-jwt. On accepte un fallback explicite via
-// FINANCE_SERVICE_ROLE_KEY (a definir via supabase secrets set si besoin).
-const SERVICE_ROLE = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
-  || Deno.env.get('FINANCE_SERVICE_ROLE_KEY')
+// Priorite au secret explicite : le runtime Supabase auto-injecte
+// SUPABASE_SERVICE_ROLE_KEY au nouveau format court (sb_secret_...),
+// qui n'est PAS un JWT et que PostgREST refuse comme Bearer. Le secret
+// FINANCE_SERVICE_ROLE_KEY doit contenir la legacy service_role au
+// format JWT (eyJ...), signee avec la cle JWT precedente encore acceptee.
+const SERVICE_ROLE = Deno.env.get('FINANCE_SERVICE_ROLE_KEY')
+  || Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
   || '';
 
 // Log de diagnostic au boot : on affiche la LONGUEUR des variables (pas
 // leur valeur) pour detecter un SERVICE_ROLE vide sans jamais logger la
-// cle elle-meme.
+// cle elle-meme. jwt_format distingue un JWT valide (3 parts) d'une cle
+// au format court (sb_secret_...) qui ne marchera pas en Bearer.
 log('info', 'finance_bridge_boot', {
   has_url: CENTRAL_URL.length > 0,
   url_host: CENTRAL_URL ? new URL(CENTRAL_URL).host : null,
   anon_len: ANON_KEY.length,
   service_role_len: SERVICE_ROLE.length,
-  service_role_source: Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
-    ? 'auto'
-    : Deno.env.get('FINANCE_SERVICE_ROLE_KEY')
-      ? 'secret'
+  service_role_source: Deno.env.get('FINANCE_SERVICE_ROLE_KEY')
+    ? 'secret'
+    : Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+      ? 'auto'
       : 'missing',
+  service_role_jwt_format: SERVICE_ROLE.split('.').length === 3,
 });
 
 const deps = {

--- a/supabase/functions/finance-bridge/index.ts
+++ b/supabase/functions/finance-bridge/index.ts
@@ -15,16 +15,14 @@
 // Variables env requises :
 //   SUPABASE_URL               Central project URL (preset par Supabase)
 //   SUPABASE_ANON_KEY          Lecture building_registry (preset par Supabase)
-//   SUPABASE_SERVICE_ROLE_KEY  Lecture clients (preset par Supabase)
-//   FINANCE_JWT_SECRET         Secret HS256 de la centrale pour minter
-//                              le JWT passe a PostgREST. A definir via :
-//                                supabase secrets set FINANCE_JWT_SECRET=...
-//                              (la valeur est le JWT Secret du dashboard
-//                              Supabase -> Project Settings -> API)
+//   SUPABASE_SERVICE_ROLE_KEY  Utilise comme Bearer pour les RPC finance
+//                              (les RPC sont SECURITY DEFINER + GRANT cible
+//                              uniquement service_role). L'Edge Function
+//                              est la frontiere de confiance ; elle a deja
+//                              valide le JWT entrant avant d'appeler.
 // -----------------------------------------------------------------------
 
 import { resolveClaims } from './lib/resolve.ts';
-import { mintCentralJwt, secretFromEnv } from './lib/jwt.ts';
 import {
   jwksResolverFor,
   makeFindBuildingByIssuer,
@@ -58,6 +56,10 @@ const deps = {
   getKeyResolver: jwksResolverFor,
 };
 
+// Pour les appels RPC finance on utilise le service_role : il bypasse la
+// RLS et permet a PostgREST d'executer la RPC sans re-verifier un JWT.
+// La securite tient parce que les RPC sont GRANTed uniquement a
+// service_role et que seule cette Edge Function detient la cle.
 const caller = makePostgrestCaller(CENTRAL_URL, ANON_KEY);
 
 // Liste blanche des endpoints exposes. Toute route inconnue retourne 404.
@@ -103,16 +105,13 @@ Deno.serve(async (req) => {
     }
   }
 
-  // Mint du JWT central utilise par PostgREST pour valider les claims.
-  const centralJwt = await mintCentralJwt(resolved.claims, { secret: secretFromEnv() });
-
   switch (endpoint) {
     case 'get-balance': {
       const result = await handleGetBalance(
         resolved.claims,
         body as never,
         caller,
-        centralJwt,
+        SERVICE_ROLE,
       );
       log('info', 'get_balance_done', {
         rid,

--- a/supabase/functions/finance-bridge/lib/central.ts
+++ b/supabase/functions/finance-bridge/lib/central.ts
@@ -1,0 +1,51 @@
+// Appels vers les RPC PostgREST centrales. Separe du handler pour que les
+// tests puissent injecter un caller fake sans avoir a mocker fetch global.
+
+export interface CentralCaller {
+  callRpc<T = unknown>(
+    rpcName: string,
+    params: Record<string, unknown>,
+    centralJwt: string,
+  ): Promise<CentralRpcResult<T>>;
+}
+
+export type CentralRpcResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; status: number; error: string; body?: unknown };
+
+// Implementation production : POST /rest/v1/rpc/<name> avec le JWT central
+// mine par mintCentralJwt. PostgREST valide la signature HS256 grace au
+// SUPABASE_JWT_SECRET partage, puis applique RLS selon les claims.
+export function makePostgrestCaller(centralUrl: string, anonKey: string): CentralCaller {
+  return {
+    async callRpc<T>(
+      rpcName: string,
+      params: Record<string, unknown>,
+      centralJwt: string,
+    ): Promise<CentralRpcResult<T>> {
+      const url = new URL(`/rest/v1/rpc/${rpcName}`, centralUrl);
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          apikey: anonKey,
+          Authorization: `Bearer ${centralJwt}`,
+          'Content-Type': 'application/json',
+          // Retourne le body JSON meme en cas d'erreur Postgres.
+          Prefer: 'return=representation',
+        },
+        body: JSON.stringify(params),
+      });
+      let body: unknown;
+      const text = await res.text();
+      try {
+        body = text ? JSON.parse(text) : null;
+      } catch {
+        body = text;
+      }
+      if (!res.ok) {
+        return { ok: false, status: res.status, error: 'RPC_FAILED', body };
+      }
+      return { ok: true, data: body as T };
+    },
+  };
+}

--- a/supabase/functions/finance-bridge/lib/jwt.ts
+++ b/supabase/functions/finance-bridge/lib/jwt.ts
@@ -1,0 +1,38 @@
+// Minting du JWT central apres resolution des claims. Le secret HS256 du
+// projet central (SUPABASE_JWT_SECRET) ne sort jamais d'ici : il est
+// injecte au demarrage de l'Edge Function et passe aux tests via fixture.
+
+import { SignJWT } from 'npm:jose@5';
+import type { ResolvedClaims } from './types.ts';
+
+export interface MintOptions {
+  secret: Uint8Array;
+  ttlSeconds?: number;   // defaut 60s
+  issuer?: string;       // defaut 'modulimo-bridge'
+}
+
+export async function mintCentralJwt(
+  claims: ResolvedClaims,
+  opts: MintOptions,
+): Promise<string> {
+  const ttl = opts.ttlSeconds ?? 60;
+  const iss = opts.issuer ?? 'modulimo-bridge';
+  return await new SignJWT({
+    building_id: claims.building_id,
+    client_id: claims.client_id,
+    cohabitat_user_id: claims.cohabitat_user_id,
+  })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setSubject(claims.client_id)
+    .setAudience('authenticated')
+    .setIssuer(iss)
+    .setIssuedAt()
+    .setExpirationTime(`${ttl}s`)
+    .sign(opts.secret);
+}
+
+export function secretFromEnv(name = 'SUPABASE_JWT_SECRET'): Uint8Array {
+  const raw = (typeof Deno !== 'undefined' ? Deno.env.get(name) : undefined) ?? '';
+  if (!raw) throw new Error(`Missing env ${name}`);
+  return new TextEncoder().encode(raw);
+}

--- a/supabase/functions/finance-bridge/lib/jwt.ts
+++ b/supabase/functions/finance-bridge/lib/jwt.ts
@@ -31,7 +31,7 @@ export async function mintCentralJwt(
     .sign(opts.secret);
 }
 
-export function secretFromEnv(name = 'SUPABASE_JWT_SECRET'): Uint8Array {
+export function secretFromEnv(name = 'FINANCE_JWT_SECRET'): Uint8Array {
   const raw = (typeof Deno !== 'undefined' ? Deno.env.get(name) : undefined) ?? '';
   if (!raw) throw new Error(`Missing env ${name}`);
   return new TextEncoder().encode(raw);

--- a/supabase/functions/finance-bridge/lib/logger.ts
+++ b/supabase/functions/finance-bridge/lib/logger.ts
@@ -1,0 +1,19 @@
+// Log structure minimal. Volontairement sans dependance : on ecrit du JSON
+// sur stdout et Supabase Logs le collecte.
+
+type Level = 'debug' | 'info' | 'warn' | 'error';
+
+export function log(level: Level, msg: string, fields: Record<string, unknown> = {}) {
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    level,
+    msg,
+    ...fields,
+  });
+  if (level === 'error' || level === 'warn') console.error(line);
+  else console.log(line);
+}
+
+export function requestId(): string {
+  return crypto.randomUUID();
+}

--- a/supabase/functions/finance-bridge/lib/registry.ts
+++ b/supabase/functions/finance-bridge/lib/registry.ts
@@ -1,0 +1,84 @@
+// Resolution building_registry via PostgREST central, puis cache JWKS.
+// Ce module assemble les adapters attendus par resolve.ts en piochant
+// directement dans la base centrale. Il n'est PAS importe par les tests
+// unitaires — les tests fabriquent leurs propres adapters in-memory.
+
+import { createRemoteJWKSet } from 'npm:jose@5';
+import type { BuildingRegistryEntry } from './types.ts';
+import type { KeyResolver } from './resolve.ts';
+
+interface BuildingRow {
+  id: string;
+  name: string;
+  supabase_url: string;
+  jwt_issuer: string;
+  jwks_url: string;
+  status: string;
+}
+
+const JWKS_CACHE = new Map<string, KeyResolver>();
+
+export function jwksResolverFor(entry: BuildingRegistryEntry): KeyResolver {
+  const cached = JWKS_CACHE.get(entry.id);
+  if (cached) return cached;
+  const resolver = createRemoteJWKSet(new URL(entry.jwks_url), {
+    // jose gere un cache interne 10 min + rotation sur kid miss.
+    cooldownDuration: 30_000,
+    timeoutDuration: 2_000,
+  });
+  JWKS_CACHE.set(entry.id, resolver);
+  return resolver;
+}
+
+export function clearJwksCache() {
+  JWKS_CACHE.clear();
+}
+
+// Lookup building_registry par issuer. Utilise la cle anon du projet central
+// avec une policy SELECT pour `authenticated` (cf. migration). On n'utilise
+// PAS la service_role ici car on lit uniquement des metadonnees publiques
+// entre immeubles.
+export function makeFindBuildingByIssuer(
+  centralUrl: string,
+  anonKey: string,
+): (iss: string) => Promise<BuildingRegistryEntry | null> {
+  return async (iss: string) => {
+    const url = new URL('/rest/v1/building_registry', centralUrl);
+    url.searchParams.set('select', 'id,name,supabase_url,jwt_issuer,jwks_url,status');
+    url.searchParams.set('jwt_issuer', `eq.${iss}`);
+    url.searchParams.set('limit', '1');
+    const res = await fetch(url, {
+      headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` },
+    });
+    if (!res.ok) return null;
+    const rows = (await res.json()) as BuildingRow[];
+    const row = rows[0];
+    if (!row) return null;
+    if (row.status !== 'active' && row.status !== 'suspended' && row.status !== 'offboarded') {
+      return null;
+    }
+    return row as BuildingRegistryEntry;
+  };
+}
+
+// Resolution cohabitat_user_id -> client_id en utilisant la service_role du
+// projet central. On bypasse la RLS ici volontairement : c'est notre role
+// d'approuver la demande, pas celui de l'immeuble.
+export function makeFindClient(
+  centralUrl: string,
+  serviceRoleKey: string,
+): (cohabitatUserId: string, buildingId: string) => Promise<{ client_id: string } | null> {
+  return async (cohabitatUserId: string, buildingId: string) => {
+    const url = new URL('/rest/v1/clients', centralUrl);
+    url.searchParams.set('select', 'id');
+    url.searchParams.set('cohabitat_user_id', `eq.${cohabitatUserId}`);
+    url.searchParams.set('building_id', `eq.${buildingId}`);
+    url.searchParams.set('limit', '1');
+    const res = await fetch(url, {
+      headers: { apikey: serviceRoleKey, Authorization: `Bearer ${serviceRoleKey}` },
+    });
+    if (!res.ok) return null;
+    const rows = (await res.json()) as Array<{ id: string }>;
+    return rows[0] ? { client_id: rows[0].id } : null;
+  };
+}

--- a/supabase/functions/finance-bridge/lib/resolve.ts
+++ b/supabase/functions/finance-bridge/lib/resolve.ts
@@ -1,0 +1,93 @@
+// Logique pure : du JWT brut jusqu'aux claims centraux resolus.
+// Aucun appel reseau direct : tout passe par les adapters injectes,
+// ce qui permet de tester chaque chemin d'echec sans mock HTTP.
+
+import { jwtVerify, type JWTPayload, type KeyLike } from 'npm:jose@5';
+import type {
+  BuildingRegistryEntry,
+  ResolveResult,
+} from './types.ts';
+
+// Re-exporte pour que les modules consommateurs (fixtures de tests,
+// handlers) n'aient qu'un seul point d'import.
+export type { BuildingRegistryEntry, ResolveResult } from './types.ts';
+
+// Un KeyResolver est la fonction que jose appelle avec le header JWT pour
+// obtenir la cle publique. En prod : createRemoteJWKSet(new URL(jwks_url)).
+// En tests : createLocalJWKSet({ keys: [...] }) retourne la meme signature.
+export type KeyResolver = Parameters<typeof jwtVerify>[1];
+
+export interface ResolveDeps {
+  findBuildingByIssuer: (iss: string) => Promise<BuildingRegistryEntry | null>;
+  getKeyResolver: (entry: BuildingRegistryEntry) => KeyResolver;
+  findClient: (
+    cohabitatUserId: string,
+    buildingId: string,
+  ) => Promise<{ client_id: string } | null>;
+}
+
+// Decode sans verifier pour lire 'iss' — c'est sur car on verifie la
+// signature juste apres. On ne fait rien confiance tant que jwtVerify
+// n'a pas valide.
+function unsafeDecodePayload(token: string): JWTPayload | null {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    return JSON.parse(atob(padded)) as JWTPayload;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveClaims(
+  token: string,
+  deps: ResolveDeps,
+): Promise<ResolveResult> {
+  const unverified = unsafeDecodePayload(token);
+  if (!unverified) return { ok: false, status: 401, error: 'MALFORMED_JWT' };
+
+  const iss = typeof unverified.iss === 'string' ? unverified.iss : null;
+  if (!iss) return { ok: false, status: 401, error: 'MISSING_ISSUER' };
+
+  const building = await deps.findBuildingByIssuer(iss);
+  if (!building) return { ok: false, status: 403, error: 'UNKNOWN_ISSUER' };
+  if (building.status !== 'active') {
+    return { ok: false, status: 403, error: 'BUILDING_INACTIVE' };
+  }
+
+  let verified: JWTPayload;
+  try {
+    const res = await jwtVerify(token, deps.getKeyResolver(building), {
+      issuer: building.jwt_issuer,
+      audience: 'authenticated',
+    });
+    verified = res.payload;
+  } catch {
+    return { ok: false, status: 401, error: 'INVALID_SIGNATURE' };
+  }
+
+  const sub = typeof verified.sub === 'string' ? verified.sub : null;
+  if (!sub) return { ok: false, status: 401, error: 'MISSING_SUBJECT' };
+
+  const client = await deps.findClient(sub, building.id);
+  if (!client) return { ok: false, status: 403, error: 'CLIENT_NOT_FOUND' };
+
+  return {
+    ok: true,
+    building,
+    claims: {
+      client_id: client.client_id,
+      building_id: building.id,
+      cohabitat_user_id: sub,
+    },
+  };
+}
+
+// Exporte pour les tests — pas pour l'app.
+export const _internals = { unsafeDecodePayload };
+
+// Re-export de type uniquement pour eviter que KeyLike soit "unused" (jose
+// l'expose, on l'annote pour les consommateurs).
+export type { KeyLike };

--- a/supabase/functions/finance-bridge/lib/types.ts
+++ b/supabase/functions/finance-bridge/lib/types.ts
@@ -1,0 +1,36 @@
+// Types partages de la passerelle finance Modulimo.
+// Aucune dependance externe : ce fichier doit rester importable depuis les
+// tests unitaires sans avoir besoin de Deno ni de Supabase.
+
+export type BuildingStatus = 'active' | 'suspended' | 'offboarded';
+
+export interface BuildingRegistryEntry {
+  id: string;               // building_registry.id (UUID)
+  name: string;
+  supabase_url: string;     // https://<ref>.supabase.co
+  jwt_issuer: string;       // <supabase_url>/auth/v1
+  jwks_url: string;         // <supabase_url>/auth/v1/.well-known/jwks.json
+  status: BuildingStatus;
+}
+
+export interface ResolvedClaims {
+  client_id: string;        // central clients.id
+  building_id: string;      // building_registry.id
+  cohabitat_user_id: string;
+}
+
+// Codes d'erreur stables : utilises par les tests et par les alertes
+// (un UNKNOWN_ISSUER frequent = tentative de forge, un CLIENT_NOT_FOUND
+// frequent = resident non approvisionne).
+export type ResolveErrorCode =
+  | 'MALFORMED_JWT'
+  | 'MISSING_ISSUER'
+  | 'MISSING_SUBJECT'
+  | 'INVALID_SIGNATURE'
+  | 'UNKNOWN_ISSUER'
+  | 'BUILDING_INACTIVE'
+  | 'CLIENT_NOT_FOUND';
+
+export type ResolveResult =
+  | { ok: true; claims: ResolvedClaims; building: BuildingRegistryEntry }
+  | { ok: false; status: number; error: ResolveErrorCode };

--- a/supabase/functions/finance-bridge/tests/_assert.ts
+++ b/supabase/functions/finance-bridge/tests/_assert.ts
@@ -1,0 +1,28 @@
+// Assertions minimales, sans dependance, pour garder le test suite
+// executable meme dans un env ou jsr/deno.land/std ne sont pas accessibles.
+// Les signatures imitent @std/assert pour faciliter une migration future.
+
+export function assertEquals<T>(actual: T, expected: T, msg?: string) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(
+      `assertEquals failed${msg ? ` (${msg})` : ''}\n  actual:   ${a}\n  expected: ${e}`,
+    );
+  }
+}
+
+export async function assertRejects(
+  fn: () => Promise<unknown>,
+  msg?: string,
+): Promise<void> {
+  let threw = false;
+  try {
+    await fn();
+  } catch {
+    threw = true;
+  }
+  if (!threw) {
+    throw new Error(`assertRejects failed : la promesse devait throw${msg ? ` (${msg})` : ''}`);
+  }
+}

--- a/supabase/functions/finance-bridge/tests/cross_tenant_test.ts
+++ b/supabase/functions/finance-bridge/tests/cross_tenant_test.ts
@@ -74,7 +74,19 @@ Deno.test('fuite #3 : JWT valide de A mais body reclame le client de B => CLIENT
   const resolved = await resolveClaims(token, deps);
   assertEquals(resolved.ok, true);
   if (!resolved.ok) return;
-  const out = handleGetBalance(resolved.claims, { client_id: 'client-b-uuid' });
+  // Caller qui throw si on l'appelle : le mismatch doit etre detecte AVANT
+  // toute requete centrale pour eviter de log inutilement une tentative.
+  const rejectingCaller = {
+    callRpc() {
+      throw new Error('RPC ne doit pas etre appele apres un mismatch');
+    },
+  };
+  const out = await handleGetBalance(
+    resolved.claims,
+    { client_id: 'client-b-uuid' },
+    rejectingCaller,
+    'unused-jwt',
+  );
   assertEquals(out.status, 403);
   assertEquals((out.body as { error: string }).error, 'CLIENT_ID_MISMATCH');
 });

--- a/supabase/functions/finance-bridge/tests/cross_tenant_test.ts
+++ b/supabase/functions/finance-bridge/tests/cross_tenant_test.ts
@@ -1,0 +1,169 @@
+// Tests de fuite inter-immeuble. Ce fichier est la garantie en CI que
+// l'Edge Function ne peut pas etre utilisee par un immeuble A pour lire
+// ou ecrire les donnees d'un immeuble B. Chaque scenario correspond a
+// une tentative d'attaque plausible.
+
+import { assertEquals } from './_assert.ts';
+import { resolveClaims } from '../lib/resolve.ts';
+import { mintCentralJwt } from '../lib/jwt.ts';
+import { handleGetBalance } from '../handlers/get_balance.ts';
+import {
+  makeBuilding,
+  makeResolveDeps,
+  setStatus,
+  signAsBuilding,
+} from './fixtures.ts';
+
+async function setup() {
+  const buildingA = await makeBuilding('building-a');
+  const buildingB = await makeBuilding('building-b');
+  const clients = [
+    {
+      cohabitat_user_id: '11111111-1111-1111-1111-111111111111',
+      building_id: buildingA.entry.id,
+      client_id: 'client-a-uuid',
+    },
+    {
+      cohabitat_user_id: '22222222-2222-2222-2222-222222222222',
+      building_id: buildingB.entry.id,
+      client_id: 'client-b-uuid',
+    },
+  ];
+  const deps = makeResolveDeps({ buildings: [buildingA, buildingB], clients });
+  return { buildingA, buildingB, clients, deps };
+}
+
+Deno.test('happy path : JWT valide de A resout vers client A', async () => {
+  const { buildingA, clients, deps } = await setup();
+  const token = await signAsBuilding(buildingA, clients[0].cohabitat_user_id);
+  const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, true);
+  if (res.ok) {
+    assertEquals(res.claims.client_id, 'client-a-uuid');
+    assertEquals(res.claims.building_id, buildingA.entry.id);
+  }
+});
+
+Deno.test('fuite #1 : JWT de A avec iss reecrit vers B => INVALID_SIGNATURE', async () => {
+  // Un attaquant qui detient un JWT valide de A tente de se faire passer
+  // pour un utilisateur de B en swappant le claim `iss`. La signature ne
+  // correspondra pas a la JWKS de B, donc rejet.
+  const { buildingA, buildingB, clients, deps } = await setup();
+  const token = await signAsBuilding(buildingA, clients[0].cohabitat_user_id, {
+    issuerOverride: buildingB.entry.jwt_issuer,
+  });
+  const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, false);
+  if (!res.ok) assertEquals(res.error, 'INVALID_SIGNATURE');
+});
+
+Deno.test('fuite #2 : JWT forge avec la mauvaise cle => INVALID_SIGNATURE', async () => {
+  const { buildingA, buildingB, clients, deps } = await setup();
+  // Attaquant signe un JWT "de A" mais avec la cle privee de B.
+  const token = await signAsBuilding(buildingA, clients[0].cohabitat_user_id, {
+    signWithKey: buildingB.privateKey,
+  });
+  const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, false);
+  if (!res.ok) assertEquals(res.error, 'INVALID_SIGNATURE');
+});
+
+Deno.test('fuite #3 : JWT valide de A mais body reclame le client de B => CLIENT_ID_MISMATCH', async () => {
+  const { buildingA, clients, deps } = await setup();
+  const token = await signAsBuilding(buildingA, clients[0].cohabitat_user_id);
+  const resolved = await resolveClaims(token, deps);
+  assertEquals(resolved.ok, true);
+  if (!resolved.ok) return;
+  const out = handleGetBalance(resolved.claims, { client_id: 'client-b-uuid' });
+  assertEquals(out.status, 403);
+  assertEquals((out.body as { error: string }).error, 'CLIENT_ID_MISMATCH');
+});
+
+Deno.test('fuite #4 : iss inconnu du registry => UNKNOWN_ISSUER', async () => {
+  const { buildingA, clients, deps } = await setup();
+  const token = await signAsBuilding(buildingA, clients[0].cohabitat_user_id, {
+    issuerOverride: 'https://rogue-building.supabase.co/auth/v1',
+  });
+  const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, false);
+  if (!res.ok) assertEquals(res.error, 'UNKNOWN_ISSUER');
+});
+
+Deno.test('fuite #5 : immeuble suspendu => BUILDING_INACTIVE', async () => {
+  const { buildingA, clients, deps } = await setup();
+  setStatus(buildingA, 'suspended');
+  const token = await signAsBuilding(buildingA, clients[0].cohabitat_user_id);
+  const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, false);
+  if (!res.ok) assertEquals(res.error, 'BUILDING_INACTIVE');
+});
+
+Deno.test('fuite #6 : cohabitat_user_id sans row clients => CLIENT_NOT_FOUND', async () => {
+  const { buildingA, deps } = await setup();
+  const token = await signAsBuilding(buildingA, '99999999-9999-9999-9999-999999999999');
+  const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, false);
+  if (!res.ok) assertEquals(res.error, 'CLIENT_NOT_FOUND');
+});
+
+Deno.test('fuite #7 : JWT expire => INVALID_SIGNATURE (jose rejette sur exp)', async () => {
+  const { buildingA, clients, deps } = await setup();
+  const token = await signAsBuilding(buildingA, clients[0].cohabitat_user_id, {
+    exp: '-1s',
+  });
+  const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, false);
+  if (!res.ok) assertEquals(res.error, 'INVALID_SIGNATURE');
+});
+
+Deno.test('fuite #8 : mauvaise audience => INVALID_SIGNATURE', async () => {
+  const { buildingA, clients, deps } = await setup();
+  const token = await signAsBuilding(buildingA, clients[0].cohabitat_user_id, {
+    audienceOverride: 'service_role',
+  });
+  const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, false);
+  if (!res.ok) assertEquals(res.error, 'INVALID_SIGNATURE');
+});
+
+Deno.test('fuite #9 : un meme cohabitat_user_id existe par hasard dans deux immeubles => on lie au bon building_id', async () => {
+  // Scenario subtil : si par coincidence l'UUID d'un user de A existe
+  // aussi dans la table clients de B, il ne faut pas que le JWT de A
+  // deverrouille l'acces a B.
+  const buildingA = await makeBuilding('building-a');
+  const buildingB = await makeBuilding('building-b');
+  const sharedUserId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+  const deps = makeResolveDeps({
+    buildings: [buildingA, buildingB],
+    clients: [
+      { cohabitat_user_id: sharedUserId, building_id: buildingA.entry.id, client_id: 'A' },
+      { cohabitat_user_id: sharedUserId, building_id: buildingB.entry.id, client_id: 'B' },
+    ],
+  });
+  const tokenFromA = await signAsBuilding(buildingA, sharedUserId);
+  const res = await resolveClaims(tokenFromA, deps);
+  assertEquals(res.ok, true);
+  if (res.ok) {
+    assertEquals(res.claims.client_id, 'A');
+    assertEquals(res.claims.building_id, buildingA.entry.id);
+  }
+});
+
+Deno.test('mint central : claims portent building_id + client_id', async () => {
+  const { buildingA, clients, deps } = await setup();
+  const token = await signAsBuilding(buildingA, clients[0].cohabitat_user_id);
+  const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, true);
+  if (!res.ok) return;
+  const secret = new TextEncoder().encode('test-secret-at-least-32-chars-long-xx');
+  const minted = await mintCentralJwt(res.claims, { secret, ttlSeconds: 60 });
+  const [, payloadB64] = minted.split('.');
+  const b64 = payloadB64.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+  const payload = JSON.parse(atob(padded));
+  assertEquals(payload.building_id, buildingA.entry.id);
+  assertEquals(payload.client_id, 'client-a-uuid');
+  assertEquals(payload.aud, 'authenticated');
+  assertEquals(payload.iss, 'modulimo-bridge');
+  assertEquals(payload.sub, 'client-a-uuid');
+});

--- a/supabase/functions/finance-bridge/tests/fixtures.ts
+++ b/supabase/functions/finance-bridge/tests/fixtures.ts
@@ -1,0 +1,113 @@
+// Fixtures de test : chaque "immeuble" est une paire de cles ES256 + un
+// issuer fictif + un JWKS derive de la cle publique. Aucun reseau, tout
+// est en memoire.
+
+import {
+  SignJWT,
+  createLocalJWKSet,
+  exportJWK,
+  generateKeyPair,
+  type KeyLike,
+} from 'npm:jose@5';
+
+import type { BuildingRegistryEntry } from '../lib/resolve.ts';
+import type { ResolveDeps } from '../lib/resolve.ts';
+import type { BuildingStatus } from '../lib/types.ts';
+
+export interface BuildingFixture {
+  entry: BuildingRegistryEntry;
+  publicKey: KeyLike;
+  privateKey: KeyLike;
+  // Les tests utilisent createLocalJWKSet : on evite ainsi toute requete
+  // reseau. Le resolver renvoie la cle publique selon le `kid` du header.
+  keyResolver: ReturnType<typeof createLocalJWKSet>;
+  kid: string;
+}
+
+export async function makeBuilding(
+  name: string,
+  overrides: Partial<Pick<BuildingRegistryEntry, 'status' | 'id'>> = {},
+): Promise<BuildingFixture> {
+  const { publicKey, privateKey } = await generateKeyPair('ES256');
+  const jwk = await exportJWK(publicKey);
+  const kid = `${name}-kid`;
+  jwk.kid = kid;
+  jwk.alg = 'ES256';
+  jwk.use = 'sig';
+  const keyResolver = createLocalJWKSet({ keys: [jwk] });
+  const supabase_url = `https://${name}.supabase.co`;
+  const jwt_issuer = `${supabase_url}/auth/v1`;
+  return {
+    entry: {
+      id: overrides.id ?? crypto.randomUUID(),
+      name,
+      supabase_url,
+      jwt_issuer,
+      jwks_url: `${jwt_issuer}/.well-known/jwks.json`,
+      status: overrides.status ?? 'active',
+    },
+    publicKey,
+    privateKey,
+    keyResolver,
+    kid,
+  };
+}
+
+// Signe un JWT comme si c'etait l'Auth Supabase de cet immeuble.
+export async function signAsBuilding(
+  b: BuildingFixture,
+  sub: string,
+  opts: {
+    exp?: string;             // '1h' par defaut
+    issuerOverride?: string;  // pour tester un iss force
+    audienceOverride?: string;
+    signWithKey?: KeyLike;    // pour tester une signature avec la mauvaise cle
+    kidOverride?: string;
+  } = {},
+): Promise<string> {
+  return await new SignJWT({})
+    .setProtectedHeader({ alg: 'ES256', kid: opts.kidOverride ?? b.kid })
+    .setSubject(sub)
+    .setIssuer(opts.issuerOverride ?? b.entry.jwt_issuer)
+    .setAudience(opts.audienceOverride ?? 'authenticated')
+    .setIssuedAt()
+    .setExpirationTime(opts.exp ?? '1h')
+    .sign(opts.signWithKey ?? b.privateKey);
+}
+
+// Fabrique des ResolveDeps in-memory a partir d'un ensemble de fixtures et
+// d'une table cohabitat_user_id -> client_id.
+export interface ResolveFixtures {
+  buildings: BuildingFixture[];
+  clients: Array<{
+    cohabitat_user_id: string;
+    building_id: string;
+    client_id: string;
+  }>;
+}
+
+export function makeResolveDeps(fx: ResolveFixtures): ResolveDeps {
+  const byIssuer = new Map(fx.buildings.map((b) => [b.entry.jwt_issuer, b]));
+  return {
+    findBuildingByIssuer: async (iss) => {
+      const b = byIssuer.get(iss);
+      return b ? b.entry : null;
+    },
+    getKeyResolver: (entry) => {
+      const b = fx.buildings.find((x) => x.entry.id === entry.id);
+      if (!b) throw new Error(`fixture missing for building ${entry.id}`);
+      return b.keyResolver;
+    },
+    findClient: async (cohabitatUserId, buildingId) => {
+      const row = fx.clients.find(
+        (c) => c.cohabitat_user_id === cohabitatUserId && c.building_id === buildingId,
+      );
+      return row ? { client_id: row.client_id } : null;
+    },
+  };
+}
+
+export function setStatus(b: BuildingFixture, status: BuildingStatus): BuildingFixture {
+  b.entry = { ...b.entry, status };
+  return b;
+}

--- a/supabase/functions/finance-bridge/tests/get_balance_test.ts
+++ b/supabase/functions/finance-bridge/tests/get_balance_test.ts
@@ -36,7 +36,11 @@ Deno.test('get-balance : happy path solde principal', async () => {
   assertEquals((out.body as { virtual_balance: number }).virtual_balance, 42);
   assertEquals((out.body as { source_kind: string }).source_kind, 'main');
   assertEquals(caller.calls[0].name, 'get_balance');
-  assertEquals(caller.calls[0].params, { p_external_dep_id: null });
+  assertEquals(caller.calls[0].params, {
+    p_client_id: 'client-a-uuid',
+    p_building_id: 'building-a-uuid',
+    p_external_dep_id: null,
+  });
   assertEquals(caller.calls[0].jwt, 'jwt-central');
 });
 
@@ -58,7 +62,11 @@ Deno.test('get-balance : dependent_id passe en parametre RPC', async () => {
   }));
   const out = await handleGetBalance(CLAIMS, { dependent_id: 'dep-42' }, caller, 'jwt');
   assertEquals(out.status, 200);
-  assertEquals(caller.calls[0].params, { p_external_dep_id: 'dep-42' });
+  assertEquals(caller.calls[0].params, {
+    p_client_id: 'client-a-uuid',
+    p_building_id: 'building-a-uuid',
+    p_external_dep_id: 'dep-42',
+  });
   assertEquals((out.body as { dependent_id: string }).dependent_id, 'dep-42');
 });
 

--- a/supabase/functions/finance-bridge/tests/get_balance_test.ts
+++ b/supabase/functions/finance-bridge/tests/get_balance_test.ts
@@ -1,0 +1,97 @@
+// Tests du handler /get-balance avec un CentralCaller fake.
+// Valide : passage du dependent_id, refus du client_id forge, propagation
+// des erreurs RPC, transformation de la reponse.
+
+import { assertEquals } from './_assert.ts';
+import { handleGetBalance } from '../handlers/get_balance.ts';
+import type { CentralCaller, CentralRpcResult } from '../lib/central.ts';
+import type { ResolvedClaims } from '../lib/types.ts';
+
+const CLAIMS: ResolvedClaims = {
+  client_id: 'client-a-uuid',
+  building_id: 'building-a-uuid',
+  cohabitat_user_id: 'user-a-uuid',
+};
+
+function fakeCaller(
+  impl: (name: string, params: Record<string, unknown>) => CentralRpcResult<unknown>,
+): CentralCaller & { calls: Array<{ name: string; params: Record<string, unknown>; jwt: string }> } {
+  const calls: Array<{ name: string; params: Record<string, unknown>; jwt: string }> = [];
+  return {
+    calls,
+    async callRpc(name, params, jwt) {
+      calls.push({ name, params, jwt });
+      return impl(name, params) as CentralRpcResult<unknown>;
+    },
+  } as ReturnType<typeof fakeCaller>;
+}
+
+Deno.test('get-balance : happy path solde principal', async () => {
+  const caller = fakeCaller(() => ({
+    ok: true,
+    data: [{ virtual_balance: '42.00', source_kind: 'main', updated_at: '2026-01-01T00:00:00Z' }],
+  }));
+  const out = await handleGetBalance(CLAIMS, null, caller, 'jwt-central');
+  assertEquals(out.status, 200);
+  assertEquals((out.body as { virtual_balance: number }).virtual_balance, 42);
+  assertEquals((out.body as { source_kind: string }).source_kind, 'main');
+  assertEquals(caller.calls[0].name, 'get_balance');
+  assertEquals(caller.calls[0].params, { p_external_dep_id: null });
+  assertEquals(caller.calls[0].jwt, 'jwt-central');
+});
+
+Deno.test('get-balance : client non provisionne => missing/0', async () => {
+  const caller = fakeCaller(() => ({
+    ok: true,
+    data: [{ virtual_balance: '0.00', source_kind: 'missing', updated_at: null }],
+  }));
+  const out = await handleGetBalance(CLAIMS, null, caller, 'jwt');
+  assertEquals(out.status, 200);
+  assertEquals((out.body as { virtual_balance: number }).virtual_balance, 0);
+  assertEquals((out.body as { source_kind: string }).source_kind, 'missing');
+});
+
+Deno.test('get-balance : dependent_id passe en parametre RPC', async () => {
+  const caller = fakeCaller(() => ({
+    ok: true,
+    data: [{ virtual_balance: '15.50', source_kind: 'dependent', updated_at: '2026-01-01T00:00:00Z' }],
+  }));
+  const out = await handleGetBalance(CLAIMS, { dependent_id: 'dep-42' }, caller, 'jwt');
+  assertEquals(out.status, 200);
+  assertEquals(caller.calls[0].params, { p_external_dep_id: 'dep-42' });
+  assertEquals((out.body as { dependent_id: string }).dependent_id, 'dep-42');
+});
+
+Deno.test('get-balance : body reclame un autre client_id => 403', async () => {
+  const caller = fakeCaller(() => {
+    throw new Error('RPC ne devrait pas etre appele');
+  });
+  const out = await handleGetBalance(CLAIMS, { client_id: 'client-b-uuid' }, caller, 'jwt');
+  assertEquals(out.status, 403);
+  assertEquals((out.body as { error: string }).error, 'CLIENT_ID_MISMATCH');
+  assertEquals(caller.calls.length, 0);
+});
+
+Deno.test('get-balance : RPC echoue en 401 => propage 401', async () => {
+  const caller = fakeCaller(() => ({
+    ok: false, status: 401, error: 'RPC_FAILED', body: { message: 'JWT expired' },
+  }));
+  const out = await handleGetBalance(CLAIMS, null, caller, 'jwt');
+  assertEquals(out.status, 401);
+  assertEquals((out.body as { error: string }).error, 'CENTRAL_RPC_FAILED');
+});
+
+Deno.test('get-balance : RPC echoue en 500 => 502 bad gateway', async () => {
+  const caller = fakeCaller(() => ({
+    ok: false, status: 500, error: 'RPC_FAILED', body: { message: 'internal' },
+  }));
+  const out = await handleGetBalance(CLAIMS, null, caller, 'jwt');
+  assertEquals(out.status, 502);
+});
+
+Deno.test('get-balance : RPC retourne tableau vide => 502', async () => {
+  const caller = fakeCaller(() => ({ ok: true, data: [] }));
+  const out = await handleGetBalance(CLAIMS, null, caller, 'jwt');
+  assertEquals(out.status, 502);
+  assertEquals((out.body as { error: string }).error, 'CENTRAL_RPC_EMPTY');
+});

--- a/supabase/functions/finance-bridge/tests/jwt_test.ts
+++ b/supabase/functions/finance-bridge/tests/jwt_test.ts
@@ -1,0 +1,58 @@
+// Tests du mint central : garantit que les claims injectes sont bien ceux
+// qui seront verifies par PostgREST avec SUPABASE_JWT_SECRET.
+
+import { assertEquals, assertRejects } from './_assert.ts';
+import { jwtVerify } from 'npm:jose@5';
+import { mintCentralJwt, secretFromEnv } from '../lib/jwt.ts';
+
+const SECRET = new TextEncoder().encode('test-secret-at-least-32-chars-long-xx');
+
+Deno.test('mint : roundtrip verify avec le bon secret', async () => {
+  const token = await mintCentralJwt(
+    {
+      client_id: 'c1',
+      building_id: 'b1',
+      cohabitat_user_id: 'u1',
+    },
+    { secret: SECRET, ttlSeconds: 60 },
+  );
+  const { payload } = await jwtVerify(token, SECRET, {
+    issuer: 'modulimo-bridge',
+    audience: 'authenticated',
+  });
+  assertEquals(payload.client_id, 'c1');
+  assertEquals(payload.building_id, 'b1');
+  assertEquals(payload.cohabitat_user_id, 'u1');
+  assertEquals(payload.sub, 'c1');
+});
+
+Deno.test('mint : verify echoue avec un mauvais secret', async () => {
+  const token = await mintCentralJwt(
+    { client_id: 'c1', building_id: 'b1', cohabitat_user_id: 'u1' },
+    { secret: SECRET },
+  );
+  const wrong = new TextEncoder().encode('another-secret-at-least-32-chars-xxxx');
+  await assertRejects(() => jwtVerify(token, wrong));
+});
+
+Deno.test('mint : expiration respectee', async () => {
+  const token = await mintCentralJwt(
+    { client_id: 'c1', building_id: 'b1', cohabitat_user_id: 'u1' },
+    { secret: SECRET, ttlSeconds: 1 },
+  );
+  // Attend au-dela de l'expiration.
+  await new Promise((r) => setTimeout(r, 1500));
+  await assertRejects(() => jwtVerify(token, SECRET, { issuer: 'modulimo-bridge' }));
+});
+
+Deno.test('secretFromEnv : erreur claire si absent', () => {
+  const prev = Deno.env.get('TEST_MISSING_SECRET');
+  Deno.env.delete('TEST_MISSING_SECRET');
+  try {
+    secretFromEnv('TEST_MISSING_SECRET');
+    throw new Error('devait throw');
+  } catch (e) {
+    assertEquals((e as Error).message.includes('TEST_MISSING_SECRET'), true);
+  }
+  if (prev) Deno.env.set('TEST_MISSING_SECRET', prev);
+});

--- a/supabase/functions/finance-bridge/tests/jwt_test.ts
+++ b/supabase/functions/finance-bridge/tests/jwt_test.ts
@@ -56,3 +56,15 @@ Deno.test('secretFromEnv : erreur claire si absent', () => {
   }
   if (prev) Deno.env.set('TEST_MISSING_SECRET', prev);
 });
+
+Deno.test('secretFromEnv : nom par defaut FINANCE_JWT_SECRET', () => {
+  const prev = Deno.env.get('FINANCE_JWT_SECRET');
+  Deno.env.set('FINANCE_JWT_SECRET', 'test-value');
+  try {
+    const bytes = secretFromEnv();
+    assertEquals(new TextDecoder().decode(bytes), 'test-value');
+  } finally {
+    if (prev !== undefined) Deno.env.set('FINANCE_JWT_SECRET', prev);
+    else Deno.env.delete('FINANCE_JWT_SECRET');
+  }
+});

--- a/supabase/functions/finance-bridge/tests/lunch_purchase_test.ts
+++ b/supabase/functions/finance-bridge/tests/lunch_purchase_test.ts
@@ -1,0 +1,167 @@
+// Tests du handler /lunch-purchase avec un CentralCaller fake.
+// Valide : validation de payload, mapping des erreurs metier (402/409/400),
+// transmission des parametres a la RPC, protection CLIENT_ID_MISMATCH.
+
+import { assertEquals } from './_assert.ts';
+import { handleLunchPurchase } from '../handlers/lunch_purchase.ts';
+import type { CentralCaller, CentralRpcResult } from '../lib/central.ts';
+import type { ResolvedClaims } from '../lib/types.ts';
+
+const CLAIMS: ResolvedClaims = {
+  client_id: 'client-a-uuid',
+  building_id: 'building-a-uuid',
+  cohabitat_user_id: 'user-a-uuid',
+};
+
+function fakeCaller(
+  impl: (name: string, params: Record<string, unknown>) => CentralRpcResult<unknown>,
+): CentralCaller & { calls: Array<{ name: string; params: Record<string, unknown> }> } {
+  const calls: Array<{ name: string; params: Record<string, unknown> }> = [];
+  return {
+    calls,
+    async callRpc(name, params) {
+      calls.push({ name, params });
+      return impl(name, params) as CentralRpcResult<unknown>;
+    },
+  } as ReturnType<typeof fakeCaller>;
+}
+
+const BASE_BODY = {
+  machine_id: 'MACH-01',
+  amount: 5.00,
+  idempotency_key: 'key-xyz',
+};
+
+Deno.test('lunch-purchase : happy path', async () => {
+  const caller = fakeCaller(() => ({
+    ok: true,
+    data: [{
+      transaction_id: 'tx-1',
+      lunch_audit_id: 'audit-1',
+      virtual_balance: '25.00',
+      idempotent_replay: false,
+    }],
+  }));
+  const out = await handleLunchPurchase(CLAIMS, BASE_BODY, caller, 'sr');
+  assertEquals(out.status, 200);
+  const body = out.body as { virtual_balance: number; transaction_id: string };
+  assertEquals(body.virtual_balance, 25);
+  assertEquals(body.transaction_id, 'tx-1');
+  assertEquals(caller.calls[0].name, 'lunch_purchase');
+  assertEquals(caller.calls[0].params.p_client_id, 'client-a-uuid');
+  assertEquals(caller.calls[0].params.p_building_id, 'building-a-uuid');
+  assertEquals(caller.calls[0].params.p_amount, 5);
+  assertEquals(caller.calls[0].params.p_idempotency_key, 'key-xyz');
+});
+
+Deno.test('lunch-purchase : replay retourne 200 avec idempotent_replay=true', async () => {
+  const caller = fakeCaller(() => ({
+    ok: true,
+    data: [{
+      transaction_id: 'tx-1', lunch_audit_id: 'audit-1',
+      virtual_balance: '25.00', idempotent_replay: true,
+    }],
+  }));
+  const out = await handleLunchPurchase(CLAIMS, BASE_BODY, caller, 'sr');
+  assertEquals(out.status, 200);
+  assertEquals((out.body as { idempotent_replay: boolean }).idempotent_replay, true);
+});
+
+Deno.test('lunch-purchase : solde insuffisant => 402', async () => {
+  const caller = fakeCaller(() => ({
+    ok: false, status: 400, error: 'RPC_FAILED',
+    body: { code: '23514', message: 'insufficient_funds : requested -100, available 30' },
+  }));
+  const out = await handleLunchPurchase(CLAIMS, BASE_BODY, caller, 'sr');
+  assertEquals(out.status, 402);
+  assertEquals((out.body as { error: string }).error, 'INSUFFICIENT_FUNDS');
+});
+
+Deno.test('lunch-purchase : idempotency_key_collision => 409', async () => {
+  const caller = fakeCaller(() => ({
+    ok: false, status: 400, error: 'RPC_FAILED',
+    body: { code: '23505', message: 'idempotency_key_collision' },
+  }));
+  const out = await handleLunchPurchase(CLAIMS, BASE_BODY, caller, 'sr');
+  assertEquals(out.status, 409);
+  assertEquals((out.body as { error: string }).error, 'IDEMPOTENCY_KEY_COLLISION');
+});
+
+Deno.test('lunch-purchase : body reclame un autre client_id => 403', async () => {
+  const caller = fakeCaller(() => {
+    throw new Error('ne doit pas etre appele');
+  });
+  const out = await handleLunchPurchase(
+    CLAIMS,
+    { ...BASE_BODY, client_id: 'client-b-uuid' },
+    caller,
+    'sr',
+  );
+  assertEquals(out.status, 403);
+  assertEquals((out.body as { error: string }).error, 'CLIENT_ID_MISMATCH');
+  assertEquals(caller.calls.length, 0);
+});
+
+Deno.test('lunch-purchase : machine_id manquant => 400', async () => {
+  const caller = fakeCaller(() => { throw new Error('ne doit pas etre appele'); });
+  const out = await handleLunchPurchase(
+    CLAIMS,
+    { ...BASE_BODY, machine_id: '' },
+    caller,
+    'sr',
+  );
+  assertEquals(out.status, 400);
+  assertEquals((out.body as { error: string }).error, 'MISSING_MACHINE_ID');
+});
+
+Deno.test('lunch-purchase : amount negatif ou zero => 400', async () => {
+  const caller = fakeCaller(() => { throw new Error('ne doit pas etre appele'); });
+  for (const amount of [0, -1, NaN, Infinity]) {
+    const out = await handleLunchPurchase(
+      CLAIMS,
+      { ...BASE_BODY, amount },
+      caller,
+      'sr',
+    );
+    assertEquals(out.status, 400, `amount=${amount}`);
+    assertEquals((out.body as { error: string }).error, 'INVALID_AMOUNT');
+  }
+});
+
+Deno.test('lunch-purchase : idempotency_key manquant => 400', async () => {
+  const caller = fakeCaller(() => { throw new Error('ne doit pas etre appele'); });
+  const out = await handleLunchPurchase(
+    CLAIMS,
+    { ...BASE_BODY, idempotency_key: '' },
+    caller,
+    'sr',
+  );
+  assertEquals(out.status, 400);
+  assertEquals((out.body as { error: string }).error, 'MISSING_IDEMPOTENCY_KEY');
+});
+
+Deno.test('lunch-purchase : dependent_id passe en p_dep_external_id', async () => {
+  const caller = fakeCaller(() => ({
+    ok: true,
+    data: [{
+      transaction_id: 'tx-1', lunch_audit_id: 'audit-1',
+      virtual_balance: '10.00', idempotent_replay: false,
+    }],
+  }));
+  await handleLunchPurchase(
+    CLAIMS,
+    { ...BASE_BODY, dependent_id: 'dep-42', slot_id: 'slot-1', buyer_name: 'Lya' },
+    caller,
+    'sr',
+  );
+  assertEquals(caller.calls[0].params.p_dep_external_id, 'dep-42');
+  assertEquals(caller.calls[0].params.p_slot_id, 'slot-1');
+  assertEquals(caller.calls[0].params.p_buyer_name, 'Lya');
+});
+
+Deno.test('lunch-purchase : body null => 400', async () => {
+  const caller = fakeCaller(() => { throw new Error('ne doit pas etre appele'); });
+  const out = await handleLunchPurchase(CLAIMS, null, caller, 'sr');
+  assertEquals(out.status, 400);
+  assertEquals((out.body as { error: string }).error, 'MISSING_BODY');
+});

--- a/supabase/functions/finance-bridge/tests/resolve_test.ts
+++ b/supabase/functions/finance-bridge/tests/resolve_test.ts
@@ -1,0 +1,57 @@
+// Tests unitaires cibles sur le parser JWT et les chemins de resolve
+// qui ne sont pas couverts par le scenario d'attaque cross-tenant.
+
+import { assertEquals } from './_assert.ts';
+import { _internals, resolveClaims } from '../lib/resolve.ts';
+import { makeBuilding, makeResolveDeps, signAsBuilding } from './fixtures.ts';
+
+Deno.test('decode : JWT malforme retourne null', () => {
+  assertEquals(_internals.unsafeDecodePayload(''), null);
+  assertEquals(_internals.unsafeDecodePayload('abc'), null);
+  assertEquals(_internals.unsafeDecodePayload('a.b'), null);
+});
+
+Deno.test('decode : header+payload valides mais JSON casse => null', () => {
+  const bogus = btoa('{}') + '.' + btoa('not json') + '.' + btoa('sig');
+  assertEquals(_internals.unsafeDecodePayload(bogus), null);
+});
+
+Deno.test('resolve : token vide => MALFORMED_JWT', async () => {
+  const b = await makeBuilding('x');
+  const deps = makeResolveDeps({ buildings: [b], clients: [] });
+  const res = await resolveClaims('', deps);
+  assertEquals(res.ok, false);
+  if (!res.ok) assertEquals(res.error, 'MALFORMED_JWT');
+});
+
+Deno.test('resolve : payload sans iss => MISSING_ISSUER', async () => {
+  const b = await makeBuilding('x');
+  const deps = makeResolveDeps({ buildings: [b], clients: [] });
+  // On fabrique un JWT valide structurellement mais sans iss.
+  // jose ajoute iss uniquement si on l'appelle — on court-circuite en
+  // manipulant le payload directement via base64url.
+  const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+    .replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+  const payload = btoa(JSON.stringify({ sub: 'x' }))
+    .replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+  const token = `${header}.${payload}.sig`;
+  const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, false);
+  if (!res.ok) assertEquals(res.error, 'MISSING_ISSUER');
+});
+
+Deno.test('resolve : sub manquant apres verification => MISSING_SUBJECT', async () => {
+  const b = await makeBuilding('x');
+  const deps = makeResolveDeps({ buildings: [b], clients: [] });
+  // Helper signe sans sub explicite — on passe une chaine vide.
+  const token = await signAsBuilding(b, '');
+  const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, false);
+  // Soit MISSING_SUBJECT (si jose laisse passer sub=''), soit
+  // INVALID_SIGNATURE selon la version. On accepte les deux — l'important
+  // c'est que le JWT ne soit pas accepte comme valide.
+  if (!res.ok) {
+    const accepted = res.error === 'MISSING_SUBJECT' || res.error === 'INVALID_SIGNATURE';
+    assertEquals(accepted, true, `error inattendue: ${res.error}`);
+  }
+});


### PR DESCRIPTION
## Contexte

Migration du solde résident depuis les DBs CoHabitat locales vers la DB centrale Modulimo, pour éliminer les bugs de cross-DB (ex: lunch_transactions qui débitait dans la mauvaise base) et permettre le covoiturage réseau inter-immeubles.

## Livré (Phase 0 à 2)

**Phase 0 — Edge Function d'auth** (`supabase/functions/finance-bridge/`)
- Valide un JWT signé par l'Auth Supabase d'un immeuble via JWKS
- Résout `cohabitat_user_id → client_id + building_id`
- Appelle les RPC centrales avec `service_role`
- 9 scénarios de fuite inter-tenant figés en CI (iss reforgé, JWT expiré, immeuble suspendu, collision UUID entre immeubles…)

**Phase 1 — Schéma central** (`sql/007_finance_central_phase1.sql` + `008_finance_central_phase1_fix.sql`)
- `building_registry` : projets Supabase des immeubles
- `clients.building_id` : scoping explicite
- `balances`, `dependent_balances` : source de vérité du solde virtuel
- `transactions` : ledger append-only (triggers BLOQUE UPDATE/DELETE)
- RPC `get_balance(p_client_id, p_building_id, p_external_dep_id)` — SECURITY DEFINER, service_role only
- 7 tests SQL (RLS bloque inter-immeuble, append-only, missing=0, etc.)

**Phase 2 — Mutations** (`sql/009_finance_central_phase2.sql`)
- RPC `adjust_balance` : primitive atomique (SELECT FOR UPDATE) avec
  - idempotency_key UNIQUE (retour = replay, pas de double débit)
  - fail-closed sur solde insuffisant (`check_violation` + rollback)
  - auto-provisioning de `balances` / `dependent_balances` au 1er mouvement
- RPC `lunch_purchase` : wrapper qui appelle `adjust_balance` + écrit `lunch_transactions` audit
- Migration défensive : renomme l'ancienne `lunch_transactions` centrale obsolète en `lunch_transactions_legacy_central` (préserve l'historique)
- 13 tests SQL supplémentaires

**Total : 38/38 tests Deno + 20/20 tests SQL verts.**

## Validé en production

Smoke tests bout-en-bout sur `bpxscgrbxjscicpnheep` + Pointe Est :

| Test | Résultat |
|---|---|
| `get-balance` → `virtual_balance: 123.45`, `source_kind: main` | ✅ |
| `lunch-purchase` 5.00 → `118.45`, `idempotent_replay: false` | ✅ |
| Retry même idempotency_key → `118.45`, `idempotent_replay: true`, même `transaction_id` | ✅ |
| `lunch-purchase` 99999 → HTTP 402 `INSUFFICIENT_FUNDS` + solde intact | ✅ |

## Déploiement

Déjà appliqué sur la centrale (SQL migrations dans l'ordre) et déployé comme Edge Function `finance-bridge`. Secret `FINANCE_SERVICE_ROLE_KEY` configuré (legacy service_role JWT) pour que l'Edge Function puisse signer ses appels à PostgREST.

## Prérequis côté immeuble (chaque projet CoHabitat)

- Activer la signature asymétrique JWT (ES256 vérifié chez Pointe Est) — sinon l'Edge Function ne peut valider les signatures sans détenir le secret HS256 de l'immeuble.

## Non inclus / prochaines étapes

- `record_real_payment` (crédit admin depuis paiement réel)
- `trip_book_network` (covoit cross-building atomique — le cas qui motivait toute l'architecture)
- Backfill historique : script de migration des soldes existants CoHabitat → centrale
- Bascule du kiosque LunchMachine sur `/finance/lunch-purchase` (retire la RPC locale CoHabitat)

## Test plan

- [x] Tests unitaires Deno (38)
- [x] Tests SQL locaux (20)
- [x] Smoke test live Phase 1 (get-balance)
- [x] Smoke test live Phase 2 (lunch-purchase + replay + insufficient_funds)
- [ ] À faire plus tard : charge test sur l'Edge Function, test de bascule kiosque

https://claude.ai/code/session_01Q1o1FLsefM8Z57Br8PpA1C