### PR TITLE
Phase 3 fondation : feature flags + réconciliation + script backfill

### DIFF
--- a/scripts/backfill-building.ts
+++ b/scripts/backfill-building.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env -S deno run --allow-env --allow-net
+// =====================================================================
+// backfill-building.ts — Migration des soldes d'un immeuble CoHabitat
+//                       vers la DB centrale Modulimo (Phase 3 step 2).
+//
+// Contexte : chaque immeuble (ex. Pointe Est = uwyhrdjlwetcbtskijrs)
+// tient aujourd'hui les soldes residents dans sa propre DB Supabase
+// (profiles.virtual_balance + transactions). Avant d'activer la bascule
+// vers central.balances, on copie l'etat existant sans rien perdre.
+//
+// Idempotence : chaque transaction CoHabitat est re-jouee via le RPC
+// adjust_balance central avec un idempotency_key stable de la forme
+// `backfill:<cohabitat_tx_id>`. Relancer le script ne produit pas de
+// double debit.
+//
+// Pre-requis :
+//   * clients.building_id + clients.cohabitat_user_id doivent deja
+//     etre remplis pour tous les residents (mapping manuel ou via un
+//     script de provisionnement). Les profiles CoHabitat sans ligne
+//     clients correspondante sont skippes + reportes dans le rapport.
+//   * L'Edge Function finance-bridge ne peut PAS etre utilisee ici car
+//     elle valide un JWT d'utilisateur. On appelle PostgREST central
+//     directement avec le service_role JWT (celui-la meme configure
+//     comme FINANCE_SERVICE_ROLE_KEY sur la fonction, ou legacy du
+//     dashboard).
+//
+// Usage :
+//   CENTRAL_URL=https://bpxscgrbxjscicpnheep.supabase.co \
+//   CENTRAL_SERVICE_ROLE=<legacy JWT service_role centrale> \
+//   COHABITAT_URL=https://uwyhrdjlwetcbtskijrs.supabase.co \
+//   COHABITAT_SERVICE_ROLE=<legacy JWT service_role immeuble> \
+//   BUILDING_ID=a41b3b31-1681-4cb1-b54c-69486d27e132 \
+//   deno run --allow-env --allow-net scripts/backfill-building.ts
+//
+// Options (env) :
+//   DRY_RUN=1           n'ecrit rien sur central, affiche le plan
+//   BATCH_SIZE=100      taille de page pour scanner les transactions
+// =====================================================================
+
+interface CohabitatProfile {
+  id: string;               // cohabitat_user_id
+  email: string;
+  full_name: string | null;
+  virtual_balance: string;
+}
+
+interface CohabitatTransaction {
+  id: string;
+  user_id: string;
+  amount: string;
+  balance_after: string;
+  type: string;
+  reference_id: string | null;
+  reference_type: string | null;
+  description: string | null;
+  created_at: string;
+  created_by: string | null;
+  is_demo: boolean;
+}
+
+interface CentralClientRow {
+  id: string;
+  cohabitat_user_id: string;
+}
+
+interface AdjustBalanceResult {
+  transaction_id: string;
+  virtual_balance: string;
+  dependent_id: string | null;
+  idempotent_replay: boolean;
+}
+
+interface BackfillReport {
+  building_id: string;
+  profiles_scanned: number;
+  profiles_without_client: string[];   // cohabitat_user_id list
+  transactions_scanned: number;
+  transactions_replayed: number;       // deja backfilles auparavant
+  transactions_applied: number;        // nouvelles ecritures
+  skipped_missing_client: number;
+  divergences: Array<{
+    client_id: string;
+    central_balance: number;
+    cohabitat_balance: number;
+    diff: number;
+  }>;
+  dry_run: boolean;
+}
+
+function env(name: string, required = true): string {
+  const v = Deno.env.get(name) ?? '';
+  if (required && !v) {
+    console.error(`Missing required env: ${name}`);
+    Deno.exit(1);
+  }
+  return v;
+}
+
+async function pgGet<T>(base: string, key: string, path: string): Promise<T> {
+  const res = await fetch(`${base}${path}`, {
+    headers: { apikey: key, Authorization: `Bearer ${key}` },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GET ${path} => ${res.status}: ${body}`);
+  }
+  return await res.json() as T;
+}
+
+async function pgRpc<T>(
+  base: string,
+  key: string,
+  fn: string,
+  params: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(`${base}/rest/v1/rpc/${fn}`, {
+    method: 'POST',
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+    },
+    body: JSON.stringify(params),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`RPC ${fn} => ${res.status}: ${text}`);
+  }
+  return (text ? JSON.parse(text) : null) as T;
+}
+
+async function main() {
+  const CENTRAL_URL = env('CENTRAL_URL');
+  const CENTRAL_SR = env('CENTRAL_SERVICE_ROLE');
+  const COHAB_URL = env('COHABITAT_URL');
+  const COHAB_SR = env('COHABITAT_SERVICE_ROLE');
+  const BUILDING_ID = env('BUILDING_ID');
+  const DRY_RUN = Deno.env.get('DRY_RUN') === '1';
+  const BATCH = Number(Deno.env.get('BATCH_SIZE') ?? '100');
+
+  const report: BackfillReport = {
+    building_id: BUILDING_ID,
+    profiles_scanned: 0,
+    profiles_without_client: [],
+    transactions_scanned: 0,
+    transactions_replayed: 0,
+    transactions_applied: 0,
+    skipped_missing_client: 0,
+    divergences: [],
+    dry_run: DRY_RUN,
+  };
+
+  console.error(`=== Backfill building=${BUILDING_ID} dry_run=${DRY_RUN} ===`);
+
+  // 1. Charge le mapping cohabitat_user_id -> client_id (centrale)
+  const clients = await pgGet<CentralClientRow[]>(
+    CENTRAL_URL,
+    CENTRAL_SR,
+    `/rest/v1/clients?select=id,cohabitat_user_id&building_id=eq.${BUILDING_ID}&cohabitat_user_id=not.is.null`,
+  );
+  const clientByCohabUser = new Map(
+    clients.map((c) => [c.cohabitat_user_id, c.id]),
+  );
+  console.error(`clients mappes : ${clientByCohabUser.size}`);
+
+  // 2. Lit TOUS les profiles CoHabitat (pages de BATCH)
+  const profiles: CohabitatProfile[] = [];
+  for (let offset = 0; ; offset += BATCH) {
+    const page = await pgGet<CohabitatProfile[]>(
+      COHAB_URL,
+      COHAB_SR,
+      `/rest/v1/profiles?select=id,email,full_name,virtual_balance&limit=${BATCH}&offset=${offset}&order=created_at.asc`,
+    );
+    profiles.push(...page);
+    if (page.length < BATCH) break;
+  }
+  report.profiles_scanned = profiles.length;
+  console.error(`profiles CoHabitat : ${profiles.length}`);
+
+  // 3. Verifie que chaque profile a un client central correspondant
+  for (const p of profiles) {
+    if (!clientByCohabUser.has(p.id)) {
+      report.profiles_without_client.push(p.id);
+    }
+  }
+  if (report.profiles_without_client.length > 0) {
+    console.error(
+      `ATTENTION : ${report.profiles_without_client.length} profile(s) sans row clients sur la centrale — seront skippes.`,
+    );
+  }
+
+  // 4. Copie les transactions CoHabitat -> central, chronologiquement
+  //    (pour que balance_after soit coherent a chaque pas). Utilise
+  //    idempotency_key = `backfill:<cohabitat_tx_id>` pour que les runs
+  //    successifs ne re-debitent pas.
+  let offset = 0;
+  while (true) {
+    const page = await pgGet<CohabitatTransaction[]>(
+      COHAB_URL,
+      COHAB_SR,
+      `/rest/v1/transactions?select=*&limit=${BATCH}&offset=${offset}&order=created_at.asc,id.asc`,
+    );
+    if (page.length === 0) break;
+
+    for (const tx of page) {
+      report.transactions_scanned++;
+      const clientId = clientByCohabUser.get(tx.user_id);
+      if (!clientId) {
+        report.skipped_missing_client++;
+        continue;
+      }
+      if (DRY_RUN) continue;
+
+      const result = await pgRpc<AdjustBalanceResult[]>(
+        CENTRAL_URL,
+        CENTRAL_SR,
+        'adjust_balance',
+        {
+          p_client_id: clientId,
+          p_building_id: BUILDING_ID,
+          p_amount: Number(tx.amount),
+          p_type: tx.type === 'demo' ? 'demo' : tx.type,
+          p_reference_id: tx.reference_id,
+          p_reference_type: tx.reference_type,
+          p_description: tx.description,
+          p_idempotency_key: `backfill:${tx.id}`,
+          p_created_by: tx.created_by,
+        },
+      );
+      const row = result?.[0];
+      if (row?.idempotent_replay) report.transactions_replayed++;
+      else report.transactions_applied++;
+    }
+    offset += page.length;
+    if (page.length < BATCH) break;
+  }
+
+  // 5. Compare central.balances avec le snapshot CoHabitat
+  const snapshot = profiles
+    .filter((p) => clientByCohabUser.has(p.id))
+    .map((p) => ({
+      cohabitat_user_id: p.id,
+      virtual_balance: p.virtual_balance,
+    }));
+
+  if (!DRY_RUN) {
+    const divergences = await pgRpc<Array<{
+      client_id: string;
+      central_balance: string;
+      cohabitat_balance: string;
+      diff: string;
+    }>>(CENTRAL_URL, CENTRAL_SR, 'reconcile_vs_cohabitat', {
+      p_building_id: BUILDING_ID,
+      p_snapshot: snapshot,
+      p_persist: true,
+    });
+    report.divergences = (divergences ?? []).map((d) => ({
+      client_id: d.client_id,
+      central_balance: Number(d.central_balance),
+      cohabitat_balance: Number(d.cohabitat_balance),
+      diff: Number(d.diff),
+    }));
+  }
+
+  console.log(JSON.stringify(report, null, 2));
+
+  if (report.divergences.length > 0) {
+    console.error(
+      `\nATTENTION : ${report.divergences.length} client(s) divergent apres backfill.`,
+    );
+    Deno.exit(2);
+  }
+  console.error('\nBackfill OK, aucune divergence.');
+}
+
+if (import.meta.main) {
+  main().catch((e) => {
+    console.error('FATAL :', e.message);
+    Deno.exit(1);
+  });
+}

--- a/sql/010_finance_central_phase3.sql
+++ b/sql/010_finance_central_phase3.sql
@@ -1,0 +1,204 @@
+-- =====================================================================
+-- 010_finance_central_phase3.sql
+-- Fondation de la Phase 3 : backfill d'un immeuble + dual-write transitoire.
+--
+--   * building_registry gagne deux flags par-immeuble :
+--       read_source        ('cohabitat' | 'central') — ou lisent les UI
+--       dual_write_enabled (bool)       — si true, mutations ecrivent des
+--                                         deux cotes pendant l'observation
+--   * reconcile_building(p_building_id) compare la somme des transactions
+--     au champ virtual_balance. Toute divergence = incident. Appele
+--     quotidiennement (pg_cron ou scheduled Edge Function).
+--   * divergence_log consigne chaque ecart detecte, avec le timestamp du
+--     run, pour suivre dans le temps.
+--
+-- Ce SQL ne deplace AUCUNE donnee : le backfill lui-meme vit cote script
+-- (scripts/backfill-building.ts) parce qu'il requiert deux DBs (CoHabitat
+-- + central), ce qui n'est pas propre en pl/pgsql.
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. Feature flags par immeuble
+-- ---------------------------------------------------------------------
+ALTER TABLE building_registry
+  ADD COLUMN IF NOT EXISTS read_source text NOT NULL DEFAULT 'cohabitat'
+    CHECK (read_source IN ('cohabitat','central')),
+  ADD COLUMN IF NOT EXISTS dual_write_enabled boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN building_registry.read_source IS
+  'Source de verite pour les lectures cote UI : "cohabitat" (default) =
+  lit profiles.virtual_balance de l''immeuble ; "central" = lit
+  balances.virtual_balance de la centrale via finance-bridge.';
+
+COMMENT ON COLUMN building_registry.dual_write_enabled IS
+  'Si true, les RPC CoHabitat ecrivent aussi sur la centrale (via
+  finance-bridge). Utilise pendant la fenetre d''observation entre le
+  backfill et la bascule definitive.';
+
+-- ---------------------------------------------------------------------
+-- 2. divergence_log : historique des ecarts detectes
+-- ---------------------------------------------------------------------
+-- Une ligne par (reconciliation_run, client_id) divergent. ok=true si la
+-- somme correspond. Les runs successifs permettent de voir si les
+-- divergences sont transitoires (retry cours) ou permanentes (incident).
+CREATE TABLE IF NOT EXISTS divergence_log (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_at           timestamptz NOT NULL DEFAULT now(),
+  building_id      uuid NOT NULL REFERENCES building_registry(id),
+  client_id        uuid NOT NULL REFERENCES clients(id),
+  kind             text NOT NULL CHECK (kind IN ('balance_vs_ledger','external_snapshot')),
+  expected         numeric(12,2) NOT NULL,
+  actual           numeric(12,2) NOT NULL,
+  diff             numeric(12,2) NOT NULL,
+  note             text
+);
+
+CREATE INDEX IF NOT EXISTS idx_divergence_log_run ON divergence_log(run_at DESC);
+CREATE INDEX IF NOT EXISTS idx_divergence_log_building ON divergence_log(building_id, run_at DESC);
+
+ALTER TABLE divergence_log ENABLE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT ON divergence_log TO service_role;
+
+-- ---------------------------------------------------------------------
+-- 3. reconcile_building : check interne (balance vs ledger)
+-- ---------------------------------------------------------------------
+-- Verifie l'invariant du ledger append-only : pour chaque client de
+-- l'immeuble, balances.virtual_balance DOIT == SUM(transactions.amount).
+-- Toute divergence = corruption de donnees (bug RPC, ecriture directe
+-- en base qui contournerait le ledger, etc.).
+CREATE OR REPLACE FUNCTION reconcile_building(
+  p_building_id uuid,
+  p_persist     boolean DEFAULT true
+) RETURNS TABLE(
+  client_id   uuid,
+  balance     numeric,
+  ledger_sum  numeric,
+  diff        numeric
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_row RECORD;
+BEGIN
+  IF p_building_id IS NULL THEN
+    RAISE EXCEPTION 'missing_building_id' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  FOR v_row IN
+    SELECT
+      b.client_id,
+      b.virtual_balance AS balance,
+      COALESCE((
+        SELECT SUM(t.amount)
+          FROM transactions t
+         WHERE t.client_id   = b.client_id
+           AND t.building_id = b.building_id
+           AND t.dependent_id IS NULL     -- reconcile ne mixe pas les deps
+      ), 0)::numeric AS ledger_sum
+    FROM balances b
+   WHERE b.building_id = p_building_id
+  LOOP
+    client_id  := v_row.client_id;
+    balance    := v_row.balance;
+    ledger_sum := v_row.ledger_sum;
+    diff       := v_row.balance - v_row.ledger_sum;
+
+    IF p_persist AND diff <> 0 THEN
+      INSERT INTO divergence_log (
+        building_id, client_id, kind, expected, actual, diff, note
+      ) VALUES (
+        p_building_id, v_row.client_id, 'balance_vs_ledger',
+        v_row.ledger_sum, v_row.balance, diff,
+        'balances.virtual_balance differe de SUM(transactions.amount)'
+      );
+    END IF;
+
+    -- Ne retourne que les lignes divergentes pour que l'appelant puisse
+    -- "IF NOT FOUND THEN ok" sans parser toute la table.
+    IF diff <> 0 THEN
+      RETURN NEXT;
+    END IF;
+  END LOOP;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION reconcile_building(uuid, boolean) FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION reconcile_building(uuid, boolean) TO service_role;
+
+-- ---------------------------------------------------------------------
+-- 4. reconcile_vs_cohabitat : compare central a un snapshot CoHabitat
+-- ---------------------------------------------------------------------
+-- Pendant l'observation Phase 3, on prend une photo des soldes CoHabitat
+-- et on la compare aux balances centrales. Le snapshot arrive sous forme
+-- de JSON : [{"cohabitat_user_id":"...", "virtual_balance":"..."}]
+-- (format stable, facile a produire avec un SELECT sur profiles).
+CREATE OR REPLACE FUNCTION reconcile_vs_cohabitat(
+  p_building_id uuid,
+  p_snapshot    jsonb,
+  p_persist     boolean DEFAULT true
+) RETURNS TABLE(
+  client_id       uuid,
+  central_balance numeric,
+  cohabitat_balance numeric,
+  diff            numeric
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_item jsonb;
+  v_client_id uuid;
+  v_coh_bal   numeric;
+  v_cent_bal  numeric;
+BEGIN
+  IF p_building_id IS NULL OR p_snapshot IS NULL THEN
+    RAISE EXCEPTION 'missing_params' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_snapshot) LOOP
+    -- Resout cohabitat_user_id -> client_id dans le registre central
+    SELECT c.id INTO v_client_id
+      FROM clients c
+     WHERE c.cohabitat_user_id = (v_item->>'cohabitat_user_id')::uuid
+       AND c.building_id       = p_building_id;
+
+    IF v_client_id IS NULL THEN
+      -- Utilisateur CoHabitat sans row clients : a traiter a part
+      -- (provisionnement non fait). On log mais on skip.
+      CONTINUE;
+    END IF;
+
+    v_coh_bal := (v_item->>'virtual_balance')::numeric;
+
+    SELECT COALESCE(b.virtual_balance, 0) INTO v_cent_bal
+      FROM balances b
+     WHERE b.client_id = v_client_id AND b.building_id = p_building_id;
+    IF v_cent_bal IS NULL THEN v_cent_bal := 0; END IF;
+
+    client_id         := v_client_id;
+    central_balance   := v_cent_bal;
+    cohabitat_balance := v_coh_bal;
+    diff              := v_cent_bal - v_coh_bal;
+
+    IF p_persist AND diff <> 0 THEN
+      INSERT INTO divergence_log (
+        building_id, client_id, kind, expected, actual, diff, note
+      ) VALUES (
+        p_building_id, v_client_id, 'external_snapshot',
+        v_coh_bal, v_cent_bal, diff,
+        'central differe du snapshot CoHabitat'
+      );
+    END IF;
+
+    IF diff <> 0 THEN
+      RETURN NEXT;
+    END IF;
+  END LOOP;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION reconcile_vs_cohabitat(uuid, jsonb, boolean) FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION reconcile_vs_cohabitat(uuid, jsonb, boolean) TO service_role;
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Contexte

Phase 3 = migration par immeuble des soldes CoHabitat vers la centrale. Ce PR pose la **fondation** : feature flags + réconciliation automatique + script de backfill idempotent. Les morceaux suivants (dual-write côté CoHabitat, bascule lecture UI) viendront dans des PRs distincts.

## Livré

### Migration SQL (`sql/010_finance_central_phase3.sql`)

- `building_registry.read_source` (`cohabitat` | `central`) + `building_registry.dual_write_enabled` : flags par-immeuble pour piloter la transition.
- Table `divergence_log` : historique des écarts détectés (run_at, building, client, kind, expected/actual/diff).
- RPC `reconcile_building(p_building_id)` : vérifie l'invariant `balance == SUM(transactions)` pour chaque client de l'immeuble. Tout écart = incident (bug RPC, écriture directe en base, etc.).
- RPC `reconcile_vs_cohabitat(p_building_id, p_snapshot)` : compare les balances centrales à un snapshot CoHabitat (JSON). Utilisé pendant la fenêtre dual-write pour détecter les dérives.
- Toutes les RPC en service_role only.

### Script de backfill (`scripts/backfill-building.ts`)

- Lit CoHabitat (`profiles` + `transactions`) via PostgREST service_role.
- Rejoue chaque transaction via `adjust_balance` central avec idempotency_key = `backfill:<cohabitat_tx_id>`. Relance sûre : pas de double débit.
- Compare final via `reconcile_vs_cohabitat`, exit 2 si divergences.
- `DRY_RUN=1` pour voir le plan sans écrire.
- Les profiles CoHabitat sans `clients.cohabitat_user_id` correspondant sont skippés et listés dans le rapport (provisioning manuel préalable requis).

## Tests

- **8 tests SQL locaux** (détection tamper, snapshot divergent, persistance conditionnelle, refus authenticated)
- Script Deno type-check clean
- Tests live du backfill → à faire par l'utilisateur en `DRY_RUN=1` d'abord

## Procédure de rollout pour Pointe Est

1. Appliquer `010_finance_central_phase3.sql` sur central.
2. `DRY_RUN=1 deno run scripts/backfill-building.ts` → inspecter le rapport (profiles sans client à provisionner).
3. Provisionner les `clients.cohabitat_user_id` manquants si nécessaire.
4. Run réel du backfill (sans `DRY_RUN`). Vérifier `divergences: []`.
5. Activer `dual_write_enabled = true` sur Pointe Est quand le PR suivant (dual-write côté cohabitat) sera déployé.
6. Observation 1-2 semaines + lancement quotidien de `reconcile_building`.
7. Si zéro divergence → `read_source = 'central'` puis arrêt écritures CoHabitat.

## À suivre

- PR dual-write dans `cohabitat` : patch des RPC locales pour appeler aussi `finance-bridge` quand le flag est actif.
- PR UI : lire depuis `finance-bridge/get-balance` quand `read_source='central'`.
- Job `pg_cron` pour `reconcile_building` quotidien + alerte Slack.

## Test plan

- [x] Tests SQL locaux
- [x] Type-check Deno
- [ ] DRY_RUN du backfill sur Pointe Est
- [ ] Backfill réel + vérification divergences=0
- [ ] PR dual-write cohabitat
- [ ] Première bascule `read_source='central'` pour Pointe Est

https://claude.ai/code/session_01Q1o1FLsefM8Z57Br8PpA1C