### PR TITLE
record_real_payment RPC + rapatriement finance-sync (Phase 3B)

### DIFF
--- a/sql/011_finance_central_phase3b_sync.sql
+++ b/sql/011_finance_central_phase3b_sync.sql
@@ -1,0 +1,121 @@
+-- =====================================================================
+-- 011_finance_central_phase3b_sync.sql
+-- Dual-write via sync periodique (Phase 3B).
+--
+-- Architecture : l'Edge Function finance-sync tourne toutes les 5 min
+-- (cron) et, pour chaque immeuble avec dual_write_enabled=true, pull
+-- les nouvelles transactions CoHabitat et les rejoue sur la centrale
+-- via adjust_balance avec idempotency_key="backfill:<cohabitat_tx_id>"
+-- (meme cle que le script manuel, evite les doubles si backfill et
+-- sync se chevauchent).
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. sync_cursor : progression par immeuble
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS sync_cursor (
+  building_id           uuid PRIMARY KEY REFERENCES building_registry(id) ON DELETE CASCADE,
+  last_synced_at        timestamptz,
+  last_synced_tx_id     uuid,
+  last_run_at           timestamptz,
+  last_run_applied      integer NOT NULL DEFAULT 0,
+  last_run_replayed     integer NOT NULL DEFAULT 0,
+  last_run_errors       integer NOT NULL DEFAULT 0,
+  last_error_message    text
+);
+
+ALTER TABLE sync_cursor ENABLE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT, UPDATE ON sync_cursor TO service_role;
+
+-- ---------------------------------------------------------------------
+-- 2. list_buildings_to_sync : quels immeubles traiter
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION list_buildings_to_sync() RETURNS TABLE(
+  building_id         uuid,
+  supabase_url        text,
+  last_synced_at      timestamptz,
+  last_synced_tx_id   uuid
+)
+LANGUAGE sql SECURITY DEFINER SET search_path = public AS $$
+  SELECT
+    br.id,
+    br.supabase_url,
+    sc.last_synced_at,
+    sc.last_synced_tx_id
+  FROM building_registry br
+  LEFT JOIN sync_cursor sc ON sc.building_id = br.id
+  WHERE br.dual_write_enabled = true
+    AND br.status = 'active'
+  ORDER BY br.id;
+$$;
+
+REVOKE ALL ON FUNCTION list_buildings_to_sync() FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION list_buildings_to_sync() TO service_role;
+
+-- ---------------------------------------------------------------------
+-- 3. record_sync_progress : update cursor + metriques du run
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION record_sync_progress(
+  p_building_id         uuid,
+  p_last_synced_at      timestamptz,
+  p_last_synced_tx_id   uuid,
+  p_applied             integer,
+  p_replayed            integer,
+  p_errors              integer,
+  p_error_message       text DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  INSERT INTO sync_cursor (
+    building_id, last_synced_at, last_synced_tx_id,
+    last_run_at, last_run_applied, last_run_replayed, last_run_errors,
+    last_error_message
+  ) VALUES (
+    p_building_id, p_last_synced_at, p_last_synced_tx_id,
+    now(), p_applied, p_replayed, p_errors, p_error_message
+  )
+  ON CONFLICT (building_id) DO UPDATE SET
+    last_synced_at     = COALESCE(EXCLUDED.last_synced_at, sync_cursor.last_synced_at),
+    last_synced_tx_id  = COALESCE(EXCLUDED.last_synced_tx_id, sync_cursor.last_synced_tx_id),
+    last_run_at        = EXCLUDED.last_run_at,
+    last_run_applied   = EXCLUDED.last_run_applied,
+    last_run_replayed  = EXCLUDED.last_run_replayed,
+    last_run_errors    = EXCLUDED.last_run_errors,
+    last_error_message = EXCLUDED.last_error_message;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION record_sync_progress(uuid, timestamptz, uuid, integer, integer, integer, text)
+  FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION record_sync_progress(uuid, timestamptz, uuid, integer, integer, integer, text)
+  TO service_role;
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';
+
+-- =====================================================================
+-- Scheduling (a executer MANUELLEMENT dans le SQL Editor apres deploy
+-- de l'Edge Function) :
+--
+--   CREATE EXTENSION IF NOT EXISTS pg_cron;
+--   CREATE EXTENSION IF NOT EXISTS pg_net;
+--
+--   SELECT cron.schedule(
+--     'finance-sync-every-5min',
+--     '*/5 * * * *',
+--     $cron$
+--       SELECT net.http_get(
+--         url := 'https://bpxscgrbxjscicpnheep.supabase.co/functions/v1/finance-sync/run',
+--         headers := jsonb_build_object(
+--           'Authorization', 'Bearer ' || current_setting('app.service_role_key'),
+--           'apikey',        current_setting('app.anon_key')
+--         )
+--       )
+--     $cron$
+--   );
+--
+--   -- Pour stopper :  SELECT cron.unschedule('finance-sync-every-5min');
+-- =====================================================================

--- a/sql/012_finance_central_record_real_payment.sql
+++ b/sql/012_finance_central_record_real_payment.sql
@@ -1,0 +1,171 @@
+-- =====================================================================
+-- 012_finance_central_record_real_payment.sql
+-- RPC record_real_payment : enregistrement d'un paiement reel par un
+-- admin Modulimo, qui credite le solde virtuel du resident en meme
+-- temps qu'il cree la ligne d'audit "paiement reel".
+--
+-- Appele par modulimo-admin (cote serveur, avec service_role) apres
+-- qu'un admin a recu cash/virement/cheque d'un resident et veut le
+-- transformer en credit virtuel utilisable dans CoHabitat.
+--
+-- Idempotent via idempotency_key comme adjust_balance et lunch_purchase.
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. Table real_payments (audit centralise)
+-- ---------------------------------------------------------------------
+-- Chaque row represente UN paiement reel recu. Liee 1:1 a une ligne
+-- transactions (le credit virtuel correspondant). Un paiement partiel
+-- se fait en plusieurs rows (pas d'update sur cette table).
+CREATE TABLE IF NOT EXISTS real_payments (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  transaction_id   uuid NOT NULL REFERENCES transactions(id),
+  client_id        uuid NOT NULL REFERENCES clients(id),
+  building_id      uuid NOT NULL REFERENCES building_registry(id),
+  amount_real      numeric(12,2) NOT NULL CHECK (amount_real > 0),
+  amount_virtual   numeric(12,2) NOT NULL CHECK (amount_virtual > 0),
+  payment_method   text NOT NULL CHECK (payment_method IN (
+    'cash','transfer','cheque','credit_card','debit_card','other'
+  )),
+  reference        text,        -- no de cheque, conf virement, etc.
+  notes            text,
+  recorded_by      uuid NOT NULL REFERENCES auth.users(id),
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (transaction_id)        -- 1 real_payment par transaction
+);
+
+CREATE INDEX IF NOT EXISTS idx_real_payments_client_created
+  ON real_payments(client_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_real_payments_building_created
+  ON real_payments(building_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_real_payments_recorder
+  ON real_payments(recorded_by, created_at DESC);
+
+ALTER TABLE real_payments ENABLE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT ON real_payments TO service_role;
+
+-- Append-only comme transactions : pas d'edition ni suppression. Une
+-- correction se fait par une nouvelle ligne de signe oppose.
+CREATE OR REPLACE FUNCTION real_payments_immutable()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'real_payments is append-only (op=%)', TG_OP
+    USING ERRCODE = 'read_only_sql_transaction';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_real_payments_no_update ON real_payments;
+CREATE TRIGGER trg_real_payments_no_update
+  BEFORE UPDATE OR DELETE ON real_payments
+  FOR EACH ROW EXECUTE FUNCTION real_payments_immutable();
+
+-- ---------------------------------------------------------------------
+-- 2. RPC record_real_payment
+-- ---------------------------------------------------------------------
+-- Logique :
+--   1. adjust_balance(+amount_virtual, type=admin_credit, idem_key)
+--      - en replay, retourne la meme transaction + real_payment lies
+--      - en nouvelle ecriture, produit une tx neuve
+--   2. Si replay, recupere la real_payment existante via transaction_id.
+--      Sinon, insere une nouvelle ligne real_payments.
+--   3. Retourne transaction_id, real_payment_id, nouveau solde, flag
+--      replay.
+--
+-- Le rigoureux UNIQUE (transaction_id) garantit 1-1 : on ne peut pas
+-- avoir deux real_payments pour une meme tx. Si la logique de replay
+-- fonctionne, on ne tentera jamais l'INSERT en replay donc pas de
+-- conflit UNIQUE.
+CREATE OR REPLACE FUNCTION record_real_payment(
+  p_client_id        uuid,
+  p_building_id      uuid,
+  p_amount_real      numeric,
+  p_amount_virtual   numeric,
+  p_payment_method   text,
+  p_reference        text DEFAULT NULL,
+  p_notes            text DEFAULT NULL,
+  p_recorded_by      uuid DEFAULT NULL,
+  p_idempotency_key  text DEFAULT NULL
+) RETURNS TABLE(
+  transaction_id    uuid,
+  real_payment_id   uuid,
+  virtual_balance   numeric,
+  idempotent_replay boolean
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_tx_id    uuid;
+  v_bal      numeric;
+  v_replay   boolean;
+  v_rp_id    uuid;
+BEGIN
+  IF p_amount_real IS NULL OR p_amount_real <= 0 THEN
+    RAISE EXCEPTION 'invalid_amount_real' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_amount_virtual IS NULL OR p_amount_virtual <= 0 THEN
+    RAISE EXCEPTION 'invalid_amount_virtual' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_recorded_by IS NULL THEN
+    RAISE EXCEPTION 'missing_recorded_by' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_idempotency_key IS NULL THEN
+    RAISE EXCEPTION 'missing_idempotency_key' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- 1. adjust_balance (credit +amount_virtual)
+  SELECT t.transaction_id, t.virtual_balance, t.idempotent_replay
+    INTO v_tx_id, v_bal, v_replay
+    FROM adjust_balance(
+      p_client_id       => p_client_id,
+      p_building_id     => p_building_id,
+      p_amount          => p_amount_virtual,
+      p_type            => 'admin_credit',
+      p_reference_type  => 'real_payment',
+      p_description     => COALESCE('Paiement ' || p_payment_method, 'Paiement reel'),
+      p_idempotency_key => p_idempotency_key,
+      p_created_by      => p_recorded_by
+    ) t;
+
+  -- 2. Real_payment : replay => lookup, sinon insert
+  IF v_replay THEN
+    SELECT rp.id INTO v_rp_id
+      FROM real_payments rp
+     WHERE rp.transaction_id = v_tx_id;
+    -- v_rp_id peut etre NULL si l'admin a appele adjust_balance avec
+    -- cette meme idem_key mais type autre que real_payment. Dans ce
+    -- cas on refuse : l'idem_key ne doit pas etre reutilisee cross-RPC.
+    IF v_rp_id IS NULL THEN
+      RAISE EXCEPTION 'idempotency_key_not_for_real_payment'
+        USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+  ELSE
+    INSERT INTO real_payments AS rp (
+      transaction_id, client_id, building_id,
+      amount_real, amount_virtual, payment_method,
+      reference, notes, recorded_by
+    ) VALUES (
+      v_tx_id, p_client_id, p_building_id,
+      p_amount_real, p_amount_virtual, p_payment_method,
+      p_reference, p_notes, p_recorded_by
+    ) RETURNING rp.id INTO v_rp_id;
+  END IF;
+
+  transaction_id    := v_tx_id;
+  real_payment_id   := v_rp_id;
+  virtual_balance   := v_bal;
+  idempotent_replay := v_replay;
+  RETURN NEXT;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION record_real_payment(
+  uuid, uuid, numeric, numeric, text, text, text, uuid, text
+) FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION record_real_payment(
+  uuid, uuid, numeric, numeric, text, text, text, uuid, text
+) TO service_role;
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/functions/finance-sync/deno.jsonc
+++ b/supabase/functions/finance-sync/deno.jsonc
@@ -1,0 +1,7 @@
+{
+  "tasks": {
+    "test": "deno test --allow-env --allow-net --no-check=remote tests/ lib/"
+  },
+  "lint": { "rules": { "tags": ["recommended"] } },
+  "fmt": { "lineWidth": 100, "indentWidth": 2, "semiColons": true, "singleQuote": true }
+}

--- a/supabase/functions/finance-sync/index.ts
+++ b/supabase/functions/finance-sync/index.ts
@@ -1,0 +1,87 @@
+// Edge Function finance-sync : worker periodique qui pull les nouvelles
+// transactions CoHabitat des immeubles avec dual_write_enabled=true et
+// les rejoue sur la centrale via adjust_balance.
+//
+// Trigger : GET /finance-sync/run (auth : Bearer service_role centrale)
+// Planning recommande : pg_cron toutes les 5 min (voir la migration 011).
+//
+// Variables env requises :
+//   SUPABASE_URL                     URL du projet central (auto-injectee)
+//   FINANCE_SERVICE_ROLE_KEY         service_role legacy JWT de la centrale
+//                                    (meme secret que finance-bridge)
+//   FINANCE_SYNC_COHABITAT_KEYS      JSON : {"<building_id>":"<service_role>"}
+//                                    service_role des projets CoHabitat
+//                                    dont on doit pouvoir lire transactions.
+
+import { syncBuilding } from './lib/sync.ts';
+import {
+  listBuildingsToSync,
+  loadCohabitatKeys,
+  makeCentralAdapters,
+  makeCohabitatFetcher,
+} from './lib/adapters.ts';
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, content-type, apikey',
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, 'content-type': 'application/json' },
+  });
+}
+
+const CENTRAL_URL = Deno.env.get('SUPABASE_URL') ?? '';
+const SERVICE_ROLE = Deno.env.get('FINANCE_SERVICE_ROLE_KEY')
+  || Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+  || '';
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response(null, { headers: CORS_HEADERS });
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    return json({ error: 'METHOD_NOT_ALLOWED' }, 405);
+  }
+
+  // Auth stricte : seul service_role peut declencher.
+  const auth = req.headers.get('authorization') ?? '';
+  const token = auth.match(/^Bearer\s+(.+)$/i)?.[1];
+  if (!token || token !== SERVICE_ROLE) {
+    return json({ error: 'UNAUTHORIZED' }, 401);
+  }
+
+  if (!CENTRAL_URL || !SERVICE_ROLE) {
+    return json({ error: 'SERVER_MISCONFIGURED' }, 500);
+  }
+
+  let cohabitatKeys: Map<string, string>;
+  try {
+    cohabitatKeys = loadCohabitatKeys();
+  } catch (e) {
+    return json({ error: 'INVALID_COHABITAT_KEYS', detail: (e as Error).message }, 500);
+  }
+
+  const central = { url: CENTRAL_URL, serviceRole: SERVICE_ROLE };
+  const centralAdapters = makeCentralAdapters(central);
+  const fetcher = makeCohabitatFetcher(cohabitatKeys);
+
+  let buildings;
+  try {
+    buildings = await listBuildingsToSync(central);
+  } catch (e) {
+    return json({ error: 'LIST_BUILDINGS_FAILED', detail: (e as Error).message }, 500);
+  }
+
+  const results = [];
+  for (const b of buildings) {
+    const r = await syncBuilding(b, {
+      ...centralAdapters,
+      fetchCohabitatTxSince: fetcher,
+    });
+    results.push(r);
+  }
+
+  return json({ ok: true, buildings: results });
+});

--- a/supabase/functions/finance-sync/lib/adapters.ts
+++ b/supabase/functions/finance-sync/lib/adapters.ts
@@ -1,0 +1,151 @@
+// Implementations concretes des adapters pour finance-sync en prod.
+// Toutes les requetes passent par PostgREST avec service_role.
+
+import type {
+  BuildingToSync,
+  CohabitatTransaction,
+  SyncResult,
+} from './types.ts';
+import type { SyncDeps } from './sync.ts';
+
+export interface CentralEnv {
+  url: string;
+  serviceRole: string;
+}
+
+// Les credentials CoHabitat sont fournies en JSON via une env unique :
+//   FINANCE_SYNC_COHABITAT_KEYS = {"<building_id>": "<service_role_jwt>"}
+// Permet d'eviter de multiplier les secrets. A eviter en prod pour plus
+// d'immeubles — voir Supabase Vault ou une table secrets chiffree.
+export function loadCohabitatKeys(): Map<string, string> {
+  const raw = Deno.env.get('FINANCE_SYNC_COHABITAT_KEYS') ?? '';
+  if (!raw) return new Map();
+  try {
+    const obj = JSON.parse(raw) as Record<string, string>;
+    return new Map(Object.entries(obj));
+  } catch (e) {
+    throw new Error(`FINANCE_SYNC_COHABITAT_KEYS is not valid JSON: ${(e as Error).message}`);
+  }
+}
+
+export function makeCohabitatFetcher(cohabitatKeys: Map<string, string>) {
+  return async (
+    building: BuildingToSync,
+    limit: number,
+  ): Promise<CohabitatTransaction[]> => {
+    const key = cohabitatKeys.get(building.building_id);
+    if (!key) {
+      throw new Error(`no FINANCE_SYNC_COHABITAT_KEYS entry for building ${building.building_id}`);
+    }
+    const url = new URL('/rest/v1/transactions', building.supabase_url);
+    url.searchParams.set(
+      'select',
+      'id,user_id,amount,type,reference_id,reference_type,description,created_at,created_by',
+    );
+    // Filtre : strictement apres le dernier curseur (both created_at et id).
+    // En cas d'egalite parfaite, un ORDER BY secondaire sur id.asc garantit
+    // la determinisme, et le filtre `gt` exclut le dernier deja sync.
+    if (building.last_synced_at) {
+      url.searchParams.set('created_at', `gte.${building.last_synced_at}`);
+    }
+    url.searchParams.set('order', 'created_at.asc,id.asc');
+    url.searchParams.set('limit', String(limit));
+
+    const res = await fetch(url, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+    });
+    if (!res.ok) {
+      throw new Error(`cohabitat fetch ${res.status}: ${await res.text()}`);
+    }
+    const rows = await res.json() as CohabitatTransaction[];
+    // Post-filtre : si created_at == last_synced_at, on skip les id <= last_synced_tx_id
+    if (building.last_synced_tx_id && building.last_synced_at) {
+      return rows.filter((r) => {
+        if (r.created_at > building.last_synced_at!) return true;
+        return r.id > building.last_synced_tx_id!;
+      });
+    }
+    return rows;
+  };
+}
+
+export function makeCentralAdapters(central: CentralEnv): Pick<
+  SyncDeps,
+  'loadClientMap' | 'callAdjustBalance' | 'recordProgress'
+> {
+  const headers = {
+    apikey: central.serviceRole,
+    Authorization: `Bearer ${central.serviceRole}`,
+    'Content-Type': 'application/json',
+  };
+
+  return {
+    loadClientMap: async (buildingId) => {
+      const url = new URL('/rest/v1/clients', central.url);
+      url.searchParams.set('select', 'id,cohabitat_user_id');
+      url.searchParams.set('building_id', `eq.${buildingId}`);
+      url.searchParams.set('cohabitat_user_id', 'not.is.null');
+      const res = await fetch(url, { headers });
+      if (!res.ok) {
+        throw new Error(`loadClientMap ${res.status}: ${await res.text()}`);
+      }
+      const rows = await res.json() as Array<{ id: string; cohabitat_user_id: string }>;
+      return new Map(rows.map((r) => [r.cohabitat_user_id, r.id]));
+    },
+
+    callAdjustBalance: async (params) => {
+      const res = await fetch(`${central.url}/rest/v1/rpc/adjust_balance`, {
+        method: 'POST',
+        headers: { ...headers, Prefer: 'return=representation' },
+        body: JSON.stringify({
+          p_client_id: params.client_id,
+          p_building_id: params.building_id,
+          p_amount: params.amount,
+          p_type: params.type,
+          p_reference_id: params.reference_id,
+          p_reference_type: params.reference_type,
+          p_description: params.description,
+          p_idempotency_key: params.idempotency_key,
+          p_created_by: params.created_by,
+        }),
+      });
+      if (!res.ok) {
+        return { ok: false, error: `${res.status}: ${await res.text()}` };
+      }
+      const rows = await res.json() as Array<{ idempotent_replay: boolean }>;
+      return { ok: true, replayed: rows[0]?.idempotent_replay ?? false };
+    },
+
+    recordProgress: async (r: SyncResult) => {
+      await fetch(`${central.url}/rest/v1/rpc/record_sync_progress`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          p_building_id: r.building_id,
+          p_last_synced_at: r.last_synced_at,
+          p_last_synced_tx_id: r.last_synced_tx_id,
+          p_applied: r.applied,
+          p_replayed: r.replayed,
+          p_errors: r.errors,
+          p_error_message: r.error_message,
+        }),
+      });
+    },
+  };
+}
+
+export async function listBuildingsToSync(central: CentralEnv): Promise<BuildingToSync[]> {
+  const res = await fetch(`${central.url}/rest/v1/rpc/list_buildings_to_sync`, {
+    method: 'POST',
+    headers: {
+      apikey: central.serviceRole,
+      Authorization: `Bearer ${central.serviceRole}`,
+      'Content-Type': 'application/json',
+    },
+    body: '{}',
+  });
+  if (!res.ok) {
+    throw new Error(`listBuildingsToSync ${res.status}: ${await res.text()}`);
+  }
+  return await res.json() as BuildingToSync[];
+}

--- a/supabase/functions/finance-sync/lib/sync.ts
+++ b/supabase/functions/finance-sync/lib/sync.ts
@@ -1,0 +1,135 @@
+// Coeur du worker de sync : pour UN immeuble, pull les nouvelles
+// transactions depuis CoHabitat et les rejoue sur central via
+// adjust_balance avec idempotency_key stable.
+
+import type {
+  BuildingToSync,
+  CohabitatTransaction,
+  SyncResult,
+} from './types.ts';
+
+export interface SyncDeps {
+  // Lecture des transactions CoHabitat nouvelles depuis le curseur.
+  // Doit retourner les rows en ordre chronologique (created_at asc, id asc)
+  // limite au batch. Vide => rien a sync.
+  fetchCohabitatTxSince: (
+    building: BuildingToSync,
+    limit: number,
+  ) => Promise<CohabitatTransaction[]>;
+
+  // Resolution cohabitat_user_id -> central client_id pour un immeuble.
+  // Un Map pre-charge au debut du run evite un roundtrip par tx.
+  loadClientMap: (
+    buildingId: string,
+  ) => Promise<Map<string, string>>;
+
+  // Appelle adjust_balance sur central. Doit retourner true si la tx a
+  // ete appliquee (ou replay idempotent), false si erreur (la tx est
+  // comptee dans errors et le cursor ne progresse pas).
+  callAdjustBalance: (params: {
+    client_id: string;
+    building_id: string;
+    amount: number;
+    type: string;
+    reference_id: string | null;
+    reference_type: string | null;
+    description: string | null;
+    idempotency_key: string;
+    created_by: string | null;
+  }) => Promise<{ ok: true; replayed: boolean } | { ok: false; error: string }>;
+
+  // Persiste la progression + metriques du run.
+  recordProgress: (r: SyncResult) => Promise<void>;
+}
+
+export async function syncBuilding(
+  building: BuildingToSync,
+  deps: SyncDeps,
+  batchSize = 200,
+): Promise<SyncResult> {
+  const result: SyncResult = {
+    building_id: building.building_id,
+    applied: 0,
+    replayed: 0,
+    skipped: 0,
+    errors: 0,
+    last_synced_tx_id: building.last_synced_tx_id,
+    last_synced_at: building.last_synced_at,
+    error_message: null,
+  };
+
+  let clientMap: Map<string, string>;
+  try {
+    clientMap = await deps.loadClientMap(building.building_id);
+  } catch (e) {
+    result.errors++;
+    result.error_message = `loadClientMap failed: ${(e as Error).message}`;
+    await deps.recordProgress(result).catch(() => {});
+    return result;
+  }
+
+  let txs: CohabitatTransaction[];
+  try {
+    txs = await deps.fetchCohabitatTxSince(building, batchSize);
+  } catch (e) {
+    result.errors++;
+    result.error_message = `fetchCohabitatTxSince failed: ${(e as Error).message}`;
+    await deps.recordProgress(result).catch(() => {});
+    return result;
+  }
+
+  // Applique dans l'ordre. Cursor ne progresse QUE pour les tx
+  // successfully appliquees contigues. Une erreur interrompt l'avancee
+  // pour que le prochain run reessaye la meme tx.
+  for (const tx of txs) {
+    const clientId = clientMap.get(tx.user_id);
+    if (!clientId) {
+      result.skipped++;
+      // On skip mais on laisse le cursor avancer : le profile n'a pas
+      // de mapping, ses tx ne seront jamais repliees tant que le
+      // provisioning manuel n'a pas ete fait. C'est un etat connu,
+      // pas une erreur qui bloque le pipeline.
+      result.last_synced_tx_id = tx.id;
+      result.last_synced_at = tx.created_at;
+      continue;
+    }
+
+    const amount = Number(tx.amount);
+    if (!Number.isFinite(amount) || amount === 0) {
+      // Ne devrait pas arriver mais protege contre les donnees corrompues.
+      result.errors++;
+      result.error_message = `invalid amount on cohabitat tx ${tx.id}`;
+      break;  // stop pour investigation
+    }
+
+    const res = await deps.callAdjustBalance({
+      client_id: clientId,
+      building_id: building.building_id,
+      amount,
+      type: tx.type,
+      reference_id: tx.reference_id,
+      reference_type: tx.reference_type,
+      description: tx.description,
+      idempotency_key: `backfill:${tx.id}`,
+      created_by: tx.created_by,
+    });
+
+    if (!res.ok) {
+      result.errors++;
+      result.error_message = `adjust_balance failed on tx ${tx.id}: ${res.error}`;
+      break;  // arret pour que la prochaine run reessaye
+    }
+
+    if (res.replayed) result.replayed++;
+    else result.applied++;
+    result.last_synced_tx_id = tx.id;
+    result.last_synced_at = tx.created_at;
+  }
+
+  await deps.recordProgress(result).catch((e) => {
+    // Si on ne peut pas persister, au moins ca remonte dans les logs.
+    result.error_message = `recordProgress failed: ${(e as Error).message}`;
+  });
+
+  return result;
+}

--- a/supabase/functions/finance-sync/lib/types.ts
+++ b/supabase/functions/finance-sync/lib/types.ts
@@ -1,0 +1,31 @@
+// Types partages du worker finance-sync. Aucune dependance Deno ici.
+
+export interface BuildingToSync {
+  building_id: string;
+  supabase_url: string;
+  last_synced_at: string | null;
+  last_synced_tx_id: string | null;
+}
+
+export interface CohabitatTransaction {
+  id: string;
+  user_id: string;
+  amount: string;                    // numeric arrivant en string
+  type: string;
+  reference_id: string | null;
+  reference_type: string | null;
+  description: string | null;
+  created_at: string;
+  created_by: string | null;
+}
+
+export interface SyncResult {
+  building_id: string;
+  applied: number;      // nouvelles tx ecrites sur central
+  replayed: number;     // tx deja vues (idempotent replay)
+  skipped: number;      // profiles sans row clients central
+  errors: number;
+  last_synced_tx_id: string | null;
+  last_synced_at: string | null;
+  error_message: string | null;
+}

--- a/supabase/functions/finance-sync/tests/_assert.ts
+++ b/supabase/functions/finance-sync/tests/_assert.ts
@@ -1,0 +1,9 @@
+export function assertEquals<T>(actual: T, expected: T, msg?: string) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(
+      `assertEquals failed${msg ? ` (${msg})` : ''}\n  actual:   ${a}\n  expected: ${e}`,
+    );
+  }
+}

--- a/supabase/functions/finance-sync/tests/sync_test.ts
+++ b/supabase/functions/finance-sync/tests/sync_test.ts
@@ -1,0 +1,159 @@
+// Tests unitaires de syncBuilding avec des adapters in-memory.
+// Aucune dependance reseau.
+
+import { assertEquals } from './_assert.ts';
+import { syncBuilding } from '../lib/sync.ts';
+import type { SyncDeps } from '../lib/sync.ts';
+import type {
+  BuildingToSync,
+  CohabitatTransaction,
+  SyncResult,
+} from '../lib/types.ts';
+
+const BUILDING: BuildingToSync = {
+  building_id: 'b1',
+  supabase_url: 'https://x.local',
+  last_synced_at: null,
+  last_synced_tx_id: null,
+};
+
+function deps(overrides: Partial<SyncDeps> & {
+  txs?: CohabitatTransaction[];
+  clients?: Record<string, string>;
+  recordProgressCalls?: SyncResult[];
+  adjustResults?: Array<{ ok: true; replayed: boolean } | { ok: false; error: string }>;
+} = {}): SyncDeps {
+  const txs = overrides.txs ?? [];
+  const clients = overrides.clients ?? {};
+  const adjustResults = overrides.adjustResults ?? [];
+  let i = 0;
+  return {
+    fetchCohabitatTxSince: overrides.fetchCohabitatTxSince
+      ?? (async () => txs),
+    loadClientMap: overrides.loadClientMap
+      ?? (async () => new Map(Object.entries(clients))),
+    callAdjustBalance: overrides.callAdjustBalance
+      ?? (async () => adjustResults[i++] ?? { ok: true, replayed: false }),
+    recordProgress: overrides.recordProgress
+      ?? (async (r) => { overrides.recordProgressCalls?.push(r); }),
+  };
+}
+
+function tx(id: string, user_id: string, amount: string, created_at: string): CohabitatTransaction {
+  return {
+    id, user_id, amount, created_at,
+    type: 'admin_credit', reference_id: null, reference_type: null,
+    description: null, created_by: null,
+  };
+}
+
+Deno.test('sync : happy path, 2 tx appliquees, cursor avance', async () => {
+  const result = await syncBuilding(BUILDING, deps({
+    txs: [
+      tx('tx1', 'u1', '10', '2026-04-01T00:00:00Z'),
+      tx('tx2', 'u1', '-5', '2026-04-01T00:01:00Z'),
+    ],
+    clients: { 'u1': 'c1' },
+    adjustResults: [
+      { ok: true, replayed: false },
+      { ok: true, replayed: false },
+    ],
+  }));
+  assertEquals(result.applied, 2);
+  assertEquals(result.replayed, 0);
+  assertEquals(result.errors, 0);
+  assertEquals(result.last_synced_tx_id, 'tx2');
+  assertEquals(result.last_synced_at, '2026-04-01T00:01:00Z');
+});
+
+Deno.test('sync : replay idempotent compte comme replayed', async () => {
+  const result = await syncBuilding(BUILDING, deps({
+    txs: [tx('tx1', 'u1', '10', '2026-04-01T00:00:00Z')],
+    clients: { 'u1': 'c1' },
+    adjustResults: [{ ok: true, replayed: true }],
+  }));
+  assertEquals(result.applied, 0);
+  assertEquals(result.replayed, 1);
+  assertEquals(result.errors, 0);
+});
+
+Deno.test('sync : profile sans client central => skipped, cursor avance', async () => {
+  const result = await syncBuilding(BUILDING, deps({
+    txs: [
+      tx('tx1', 'u-unknown', '10', '2026-04-01T00:00:00Z'),
+      tx('tx2', 'u1', '20', '2026-04-01T00:01:00Z'),
+    ],
+    clients: { 'u1': 'c1' },
+    adjustResults: [{ ok: true, replayed: false }],
+  }));
+  assertEquals(result.applied, 1);
+  assertEquals(result.skipped, 1);
+  assertEquals(result.errors, 0);
+  assertEquals(result.last_synced_tx_id, 'tx2');
+});
+
+Deno.test('sync : erreur adjust_balance stoppe le run, cursor pas avance sur la tx en echec', async () => {
+  const result = await syncBuilding(BUILDING, deps({
+    txs: [
+      tx('tx1', 'u1', '10', '2026-04-01T00:00:00Z'),
+      tx('tx2', 'u1', '20', '2026-04-01T00:01:00Z'),
+      tx('tx3', 'u1', '30', '2026-04-01T00:02:00Z'),
+    ],
+    clients: { 'u1': 'c1' },
+    adjustResults: [
+      { ok: true, replayed: false },
+      { ok: false, error: 'timeout' },
+      { ok: true, replayed: false }, // ne devrait pas etre appele
+    ],
+  }));
+  assertEquals(result.applied, 1);
+  assertEquals(result.errors, 1);
+  assertEquals(result.last_synced_tx_id, 'tx1');
+  assertEquals(result.error_message?.includes('tx2'), true);
+});
+
+Deno.test('sync : loadClientMap throw => erreur remontee sans applique', async () => {
+  const result = await syncBuilding(BUILDING, deps({
+    loadClientMap: async () => { throw new Error('network'); },
+  }));
+  assertEquals(result.applied, 0);
+  assertEquals(result.errors, 1);
+  assertEquals(result.error_message?.includes('loadClientMap'), true);
+});
+
+Deno.test('sync : amount invalide stoppe + error', async () => {
+  const result = await syncBuilding(BUILDING, deps({
+    txs: [tx('tx1', 'u1', 'NaN', '2026-04-01T00:00:00Z')],
+    clients: { 'u1': 'c1' },
+  }));
+  assertEquals(result.applied, 0);
+  assertEquals(result.errors, 1);
+  assertEquals(result.error_message?.includes('invalid amount'), true);
+});
+
+Deno.test('sync : idempotency_key stable = backfill:<tx_id>', async () => {
+  const calls: string[] = [];
+  const result = await syncBuilding(BUILDING, deps({
+    txs: [tx('abc123', 'u1', '10', '2026-04-01T00:00:00Z')],
+    clients: { 'u1': 'c1' },
+    callAdjustBalance: async (p) => {
+      calls.push(p.idempotency_key);
+      return { ok: true, replayed: false };
+    },
+  }));
+  assertEquals(calls[0], 'backfill:abc123');
+  assertEquals(result.applied, 1);
+});
+
+Deno.test('sync : recordProgress recoit le resultat final', async () => {
+  const recorded: SyncResult[] = [];
+  await syncBuilding(BUILDING, deps({
+    txs: [tx('tx1', 'u1', '10', '2026-04-01T00:00:00Z')],
+    clients: { 'u1': 'c1' },
+    recordProgress: async (r) => { recorded.push(r); },
+    adjustResults: [{ ok: true, replayed: false }],
+  }));
+  assertEquals(recorded.length, 1);
+  assertEquals(recorded[0].applied, 1);
+  assertEquals(recorded[0].last_synced_tx_id, 'tx1');
+});


### PR DESCRIPTION
## Contenu

Deux morceaux dans cette PR :

### 1. RPC `record_real_payment` (nouveau)

Admin enregistre un paiement réel (cash/virement/chèque) et crédite le solde virtuel du résident de façon atomique.

- Table `real_payments` (audit immuable, trigger `BLOQUE UPDATE/DELETE`, 1-1 avec `transactions` via UNIQUE)
- RPC `record_real_payment(client_id, building_id, amount_real, amount_virtual, payment_method, reference, notes, recorded_by, idempotency_key)`
- Idempotent via `adjust_balance` — replay retourne la même ligne
- Défense : refuse si `idempotency_key` a déjà servi pour un autre type de RPC
- service_role only (appelé par modulimo-admin côté serveur)

**9 tests SQL verts** (happy path, replay, amount invalide, method inconnue, cross-RPC idem refusé, append-only, authenticated refusé, recorded_by null).

### 2. Rapatriement de Phase 3B (finance-sync)

Le commit `ca15302` (worker `finance-sync` + migration `011`) avait été poussé juste après la fermeture de PR #8 et n'était donc pas arrivé sur `main`. Cette PR le remet en place.

## Test plan

- [x] Migrations SQL appliquées localement (8 fichiers, 0 erreur)
- [x] 9 tests record_real_payment verts
- [x] 8 tests finance-sync verts (rapatriés du travail précédent)
- [ ] Appliquer `011` + `012` sur la centrale
- [ ] Déployer `finance-sync` Edge Function
- [ ] Setter `FINANCE_SYNC_COHABITAT_KEYS` avec Pointe Est
- [ ] Brancher la UI modulimo-admin sur `record_real_payment` (prochaine étape, repo modulimo-admin aussi)

https://claude.ai/code/session_01Q1o1FLsefM8Z57Br8PpA1C