### PR TITLE
Phase 3D : endpoint /debit générique sur finance-bridge

### DIFF
--- a/supabase/functions/finance-bridge/handlers/debit.ts
+++ b/supabase/functions/finance-bridge/handlers/debit.ts
@@ -1,0 +1,141 @@
+// Endpoint generique POST /finance-bridge/debit.
+// Wrap adjust_balance avec whitelist de types pour que les residents
+// puissent debiter leurs comptes (reservations, etc.) mais jamais se
+// crediter hors des refunds prevus.
+
+import type { ResolvedClaims } from '../lib/types.ts';
+import type { CentralCaller } from '../lib/central.ts';
+
+// Types autorises en tant que debit resident (amount doit etre < 0).
+const ALLOWED_DEBIT_TYPES = [
+  'space_reservation',
+  'trip_booking',
+  'trip_cancel_charge',
+  'trip_driver_charge',
+] as const;
+
+// Types autorises en tant que refund resident (amount doit etre > 0).
+// Un user ne peut refund qu'une transaction existante qu'il a lui-meme
+// faite ; cela est garanti par le RLS + le reference_id fourni, pas
+// par cette fonction. On whitelist juste les types.
+const ALLOWED_REFUND_TYPES = [
+  'space_cancel_refund',
+  'trip_cancel_refund',
+  'trip_driver_earning',
+] as const;
+
+type AllowedType =
+  | typeof ALLOWED_DEBIT_TYPES[number]
+  | typeof ALLOWED_REFUND_TYPES[number];
+
+export interface DebitRequest {
+  client_id?: string;          // optionnel, verifie == claims.client_id
+  dependent_id?: string | null;
+  amount: number;              // < 0 pour debit, > 0 pour refund
+  type: AllowedType;
+  description?: string | null;
+  reference_id?: string | null;
+  reference_type?: string | null;
+  idempotency_key: string;
+}
+
+interface RpcRow {
+  transaction_id: string;
+  virtual_balance: number | string;
+  dependent_id: string | null;
+  idempotent_replay: boolean;
+}
+
+export interface DebitResponse {
+  client_id: string;
+  building_id: string;
+  transaction_id: string;
+  virtual_balance: number;
+  idempotent_replay: boolean;
+}
+
+function isAllowedType(t: unknown): t is AllowedType {
+  if (typeof t !== 'string') return false;
+  return (ALLOWED_DEBIT_TYPES as readonly string[]).includes(t)
+    || (ALLOWED_REFUND_TYPES as readonly string[]).includes(t);
+}
+
+function isDebitType(t: AllowedType): boolean {
+  return (ALLOWED_DEBIT_TYPES as readonly string[]).includes(t);
+}
+
+export async function handleDebit(
+  claims: ResolvedClaims,
+  body: DebitRequest | null,
+  caller: CentralCaller,
+  serviceRole: string,
+): Promise<{
+  status: number;
+  body: DebitResponse | { error: string; detail?: unknown };
+}> {
+  if (!body) return { status: 400, body: { error: 'MISSING_BODY' } };
+  if (body.client_id && body.client_id !== claims.client_id) {
+    return { status: 403, body: { error: 'CLIENT_ID_MISMATCH' } };
+  }
+  if (!isAllowedType(body.type)) {
+    return { status: 400, body: { error: 'TYPE_NOT_ALLOWED' } };
+  }
+  if (typeof body.amount !== 'number' || !Number.isFinite(body.amount) || body.amount === 0) {
+    return { status: 400, body: { error: 'INVALID_AMOUNT' } };
+  }
+  // Enforcement signe vs type : un debit_type doit avoir un amount < 0,
+  // un refund_type doit avoir un amount > 0. Evite qu'un client tape
+  // space_reservation avec +100 pour se crediter.
+  const shouldBeNegative = isDebitType(body.type);
+  if (shouldBeNegative && body.amount >= 0) {
+    return { status: 400, body: { error: 'AMOUNT_SIGN_MISMATCH' } };
+  }
+  if (!shouldBeNegative && body.amount <= 0) {
+    return { status: 400, body: { error: 'AMOUNT_SIGN_MISMATCH' } };
+  }
+  if (!body.idempotency_key || typeof body.idempotency_key !== 'string') {
+    return { status: 400, body: { error: 'MISSING_IDEMPOTENCY_KEY' } };
+  }
+
+  const res = await caller.callRpc<RpcRow[]>(
+    'adjust_balance',
+    {
+      p_client_id: claims.client_id,
+      p_building_id: claims.building_id,
+      p_dep_external_id: body.dependent_id ?? null,
+      p_amount: body.amount,
+      p_type: body.type,
+      p_reference_id: body.reference_id ?? null,
+      p_reference_type: body.reference_type ?? null,
+      p_description: body.description ?? null,
+      p_idempotency_key: body.idempotency_key,
+      p_created_by: null,
+    },
+    serviceRole,
+  );
+
+  if (!res.ok) {
+    const detail = res.body as { code?: string; message?: string } | undefined;
+    const code = detail?.code;
+    if (code === '23514' || detail?.message?.includes('insufficient_funds')) {
+      return { status: 402, body: { error: 'INSUFFICIENT_FUNDS', detail: res.body } };
+    }
+    if (code === '22023') return { status: 400, body: { error: 'INVALID_PARAMETER', detail: res.body } };
+    if (code === '23505') return { status: 409, body: { error: 'IDEMPOTENCY_KEY_COLLISION', detail: res.body } };
+    return { status: 502, body: { error: 'CENTRAL_RPC_FAILED', detail: res.body } };
+  }
+
+  const row = Array.isArray(res.data) ? res.data[0] : null;
+  if (!row) return { status: 502, body: { error: 'CENTRAL_RPC_EMPTY' } };
+
+  return {
+    status: 200,
+    body: {
+      client_id: claims.client_id,
+      building_id: claims.building_id,
+      transaction_id: row.transaction_id,
+      virtual_balance: Number(row.virtual_balance),
+      idempotent_replay: row.idempotent_replay,
+    },
+  };
+}

--- a/supabase/functions/finance-bridge/index.ts
+++ b/supabase/functions/finance-bridge/index.ts
@@ -31,6 +31,7 @@ import {
 import { makePostgrestCaller } from './lib/central.ts';
 import { handleGetBalance } from './handlers/get_balance.ts';
 import { handleLunchPurchase } from './handlers/lunch_purchase.ts';
+import { handleDebit } from './handlers/debit.ts';
 import { log, requestId } from './lib/logger.ts';
 
 const CORS_HEADERS: Record<string, string> = {
@@ -88,10 +89,11 @@ const deps = {
 const caller = makePostgrestCaller(CENTRAL_URL, ANON_KEY);
 
 // Liste blanche des endpoints exposes. Toute route inconnue retourne 404.
-type EndpointName = 'get-balance' | 'lunch-purchase';
+type EndpointName = 'get-balance' | 'lunch-purchase' | 'debit';
 const ENDPOINTS: Record<EndpointName, true> = {
   'get-balance': true,
   'lunch-purchase': true,
+  'debit': true,
 };
 
 function extractEndpoint(pathname: string): EndpointName | null {
@@ -172,6 +174,24 @@ Deno.serve(async (req) => {
         status: result.status,
         building_id: resolved.claims.building_id,
         client_id: resolved.claims.client_id,
+        replay: (result.body as { idempotent_replay?: boolean }).idempotent_replay,
+      });
+      return json(result.body, result.status);
+    }
+    case 'debit': {
+      const result = await handleDebit(
+        resolved.claims,
+        body as never,
+        caller,
+        SERVICE_ROLE,
+      );
+      log(result.status >= 500 ? 'error' : 'info', 'debit_done', {
+        rid,
+        endpoint,
+        status: result.status,
+        building_id: resolved.claims.building_id,
+        client_id: resolved.claims.client_id,
+        type: (body as { type?: string } | null)?.type,
         replay: (result.body as { idempotent_replay?: boolean }).idempotent_replay,
       });
       return json(result.body, result.status);

--- a/supabase/functions/finance-bridge/tests/debit_test.ts
+++ b/supabase/functions/finance-bridge/tests/debit_test.ts
@@ -1,0 +1,147 @@
+// Tests du handler /debit avec un CentralCaller fake.
+
+import { assertEquals } from './_assert.ts';
+import { handleDebit } from '../handlers/debit.ts';
+import type { CentralCaller, CentralRpcResult } from '../lib/central.ts';
+import type { ResolvedClaims } from '../lib/types.ts';
+
+const CLAIMS: ResolvedClaims = {
+  client_id: 'client-a-uuid',
+  building_id: 'building-a-uuid',
+  cohabitat_user_id: 'user-a-uuid',
+};
+
+function fakeCaller(
+  impl: (name: string, params: Record<string, unknown>) => CentralRpcResult<unknown>,
+): CentralCaller & { calls: Array<{ name: string; params: Record<string, unknown> }> } {
+  const calls: Array<{ name: string; params: Record<string, unknown> }> = [];
+  return {
+    calls,
+    async callRpc(name, params) {
+      calls.push({ name, params });
+      return impl(name, params) as CentralRpcResult<unknown>;
+    },
+  } as ReturnType<typeof fakeCaller>;
+}
+
+Deno.test('debit : happy path space_reservation', async () => {
+  const caller = fakeCaller(() => ({
+    ok: true,
+    data: [{ transaction_id: 'tx-1', virtual_balance: '739.50', dependent_id: null, idempotent_replay: false }],
+  }));
+  const out = await handleDebit(
+    CLAIMS,
+    { amount: -11.50, type: 'space_reservation', idempotency_key: 'k1' },
+    caller,
+    'sr',
+  );
+  assertEquals(out.status, 200);
+  assertEquals((out.body as { virtual_balance: number }).virtual_balance, 739.5);
+  assertEquals(caller.calls[0].params.p_type, 'space_reservation');
+});
+
+Deno.test('debit : type non whitelist => 400', async () => {
+  const caller = fakeCaller(() => { throw new Error('unreachable'); });
+  const out = await handleDebit(
+    CLAIMS,
+    { amount: -10, type: 'admin_credit' as never, idempotency_key: 'k' },
+    caller, 'sr',
+  );
+  assertEquals(out.status, 400);
+  assertEquals((out.body as { error: string }).error, 'TYPE_NOT_ALLOWED');
+});
+
+Deno.test('debit : debit_type avec amount positif => AMOUNT_SIGN_MISMATCH', async () => {
+  const caller = fakeCaller(() => { throw new Error('unreachable'); });
+  const out = await handleDebit(
+    CLAIMS,
+    { amount: 100, type: 'space_reservation', idempotency_key: 'k' },
+    caller, 'sr',
+  );
+  assertEquals(out.status, 400);
+  assertEquals((out.body as { error: string }).error, 'AMOUNT_SIGN_MISMATCH');
+});
+
+Deno.test('debit : refund_type avec amount negatif => AMOUNT_SIGN_MISMATCH', async () => {
+  const caller = fakeCaller(() => { throw new Error('unreachable'); });
+  const out = await handleDebit(
+    CLAIMS,
+    { amount: -5, type: 'space_cancel_refund', idempotency_key: 'k' },
+    caller, 'sr',
+  );
+  assertEquals(out.status, 400);
+  assertEquals((out.body as { error: string }).error, 'AMOUNT_SIGN_MISMATCH');
+});
+
+Deno.test('debit : space_cancel_refund accepte amount positif', async () => {
+  const caller = fakeCaller(() => ({
+    ok: true,
+    data: [{ transaction_id: 'tx-2', virtual_balance: '750.00', dependent_id: null, idempotent_replay: false }],
+  }));
+  const out = await handleDebit(
+    CLAIMS,
+    { amount: 11.50, type: 'space_cancel_refund', idempotency_key: 'k2' },
+    caller, 'sr',
+  );
+  assertEquals(out.status, 200);
+});
+
+Deno.test('debit : amount 0 refuse', async () => {
+  const caller = fakeCaller(() => { throw new Error('unreachable'); });
+  const out = await handleDebit(
+    CLAIMS,
+    { amount: 0, type: 'space_reservation', idempotency_key: 'k' },
+    caller, 'sr',
+  );
+  assertEquals(out.status, 400);
+  assertEquals((out.body as { error: string }).error, 'INVALID_AMOUNT');
+});
+
+Deno.test('debit : INSUFFICIENT_FUNDS => 402', async () => {
+  const caller = fakeCaller(() => ({
+    ok: false, status: 400, error: 'RPC_FAILED',
+    body: { code: '23514', message: 'insufficient_funds : requested -10000, available 10.00' },
+  }));
+  const out = await handleDebit(
+    CLAIMS,
+    { amount: -10000, type: 'space_reservation', idempotency_key: 'k' },
+    caller, 'sr',
+  );
+  assertEquals(out.status, 402);
+  assertEquals((out.body as { error: string }).error, 'INSUFFICIENT_FUNDS');
+});
+
+Deno.test('debit : client_id du body different du JWT => 403', async () => {
+  const caller = fakeCaller(() => { throw new Error('unreachable'); });
+  const out = await handleDebit(
+    CLAIMS,
+    { amount: -10, type: 'space_reservation', idempotency_key: 'k', client_id: 'other' },
+    caller, 'sr',
+  );
+  assertEquals(out.status, 403);
+  assertEquals((out.body as { error: string }).error, 'CLIENT_ID_MISMATCH');
+});
+
+Deno.test('debit : idempotency_key manquant => 400', async () => {
+  const caller = fakeCaller(() => { throw new Error('unreachable'); });
+  const out = await handleDebit(
+    CLAIMS,
+    { amount: -10, type: 'space_reservation' } as never,
+    caller, 'sr',
+  );
+  assertEquals(out.status, 400);
+  assertEquals((out.body as { error: string }).error, 'MISSING_IDEMPOTENCY_KEY');
+});
+
+Deno.test('debit : dependent_id passe en p_dep_external_id', async () => {
+  const caller = fakeCaller(() => ({
+    ok: true,
+    data: [{ transaction_id: 't', virtual_balance: '0', dependent_id: 'd', idempotent_replay: false }],
+  }));
+  await handleDebit(
+    CLAIMS,
+    { amount: -2, type: 'space_reservation', idempotency_key: 'k', dependent_id: 'dep-42' },
+    caller, 'sr',
+  );
+  assertEquals(caller.calls[0].params.p_dep_external_id, 'dep-42');
+});


### PR DESCRIPTION
## Contexte

Après Phase 3C (UI lit central), les écritures locales CoHabitat créent une fenêtre de 5 min où un reload peut afficher un solde stale (central pas encore mis à jour par finance-sync). Cette PR expose un endpoint générique `/debit` sur `finance-bridge` pour que CoHabitat puisse court-circuiter cette latence : central devient source d'autorité en temps réel.

## Endpoint

```
POST /finance-bridge/debit
Authorization: Bearer <resident JWT>
Body: { amount, type, description?, reference_id?, reference_type?, dependent_id?, idempotency_key }
```

### Whitelist de types
- **Débits** (amount < 0) : `space_reservation`, `trip_booking`, `trip_cancel_charge`, `trip_driver_charge`
- **Refunds** (amount > 0) : `space_cancel_refund`, `trip_cancel_refund`, `trip_driver_earning`
- **Refusé** : `admin_credit` (réservé à `record_real_payment` avec auth admin distincte)

### Sécurité
- Signe forcé selon type : un résident ne peut pas taper `space_reservation` avec `+100` pour se créditer
- `CLIENT_ID_MISMATCH` protection préservée (comme `/get-balance`, `/lunch-purchase`)
- idempotency_key requis — pas de default côté serveur
- `SQLSTATE 23514` (insufficient_funds) → HTTP 402 ; `23505` (idempotency collision) → 409

## Tests

- 10 tests Deno dédiés pour `/debit`
- 48 tests total sur finance-bridge (tous verts)
- Pas de test SQL nouveau : le endpoint est un thin wrapper sur `adjust_balance` (couvert par Phase 2)

## À utiliser

Voir PR associée dans `cohabitat` pour le pilote UI (`reserveSpace`). Le bouton covoit n'est pas inclus — sera migré quand le module trajets passera dans son propre repo.

## Non inclus
- `trip_book_network` (cross-building atomique) reste TODO
- Pas de flows trajet dans CoHabitat UI

https://claude.ai/code/session_01Q1o1FLsefM8Z57Br8PpA1C

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1o1FLsefM8Z57Br8PpA1C)_