### PR TITLE
Phase 3D : endpoints transfer-to-dep + record-real-payment

### DIFF
--- a/sql/014_finance_central_transfer_to_dep.sql
+++ b/sql/014_finance_central_transfer_to_dep.sql
@@ -1,0 +1,158 @@
+-- =====================================================================
+-- 014_finance_central_transfer_to_dep.sql
+-- RPC transfer_to_dependent_central : equivalent atomique cote central de
+-- la RPC locale CoHabitat transfer_to_dependent. Le parent debite son
+-- solde principal et le dependant en recoit le credit, en une seule
+-- transaction PG. Si le credit echoue, le debit roll-back automatiquement
+-- (pas de fenetre ou le parent a perdu sans que le dep recoive).
+--
+-- Appele par finance-bridge/transfer-to-dep depuis l'UI CoHabitat quand
+-- finance_central_enabled=true. Avant ca, le transfert ne touchait que
+-- profiles.virtual_balance / dependents.virtual_balance localement et la
+-- centrale n'en voyait jamais trace.
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. Etendre le whitelist de transactions.type
+-- ---------------------------------------------------------------------
+-- Le CHECK est inline dans le CREATE TABLE de sql/007, le nom auto-genere
+-- par PG est 'transactions_type_check'. Si la version locale a un nom
+-- different (rare), on cherche dynamiquement dans pg_constraint avant de
+-- drop pour eviter l'echec silencieux du DROP IF EXISTS.
+DO $$
+DECLARE
+  v_constraint_name text;
+BEGIN
+  SELECT conname INTO v_constraint_name
+    FROM pg_constraint
+   WHERE conrelid = 'public.transactions'::regclass
+     AND contype = 'c'
+     AND pg_get_constraintdef(oid) ILIKE '%type%IN%';
+  IF v_constraint_name IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE public.transactions DROP CONSTRAINT ' || quote_ident(v_constraint_name);
+  END IF;
+END $$;
+
+ALTER TABLE transactions ADD CONSTRAINT transactions_type_check
+  CHECK (type IN (
+    'admin_credit',
+    'space_reservation',
+    'space_cancel_refund',
+    'trip_booking',
+    'trip_cancel_refund',
+    'trip_cancel_charge',
+    'trip_driver_earning',
+    'trip_driver_charge',
+    'lunch_purchase',
+    'demo',
+    -- Transfert atomique parent -> dependant (Phase 3D)
+    'transfer_to_dependent',   -- ligne ledger cote parent (debit)
+    'transfer_from_parent'     -- ligne ledger cote dependant (credit)
+  ));
+
+-- ---------------------------------------------------------------------
+-- 2. RPC transfer_to_dependent_central
+-- ---------------------------------------------------------------------
+-- Logique :
+--   1. adjust_balance(parent, -amount, type='transfer_to_dependent')
+--      Idempotency-key derivee : <p_idempotency_key>:out
+--   2. adjust_balance(dep,    +amount, type='transfer_from_parent')
+--      Idempotency-key derivee : <p_idempotency_key>:in
+--
+-- Les deux appels partagent la meme transaction PG : si le 2e plante
+-- (insufficient_funds est impossible cote credit, mais p.ex. dep_external_id
+-- vide ou format invalide), le ROLLBACK annule le 1er, on n'a pas de trou.
+--
+-- Idempotence : si le client retry avec la meme p_idempotency_key, les deux
+-- adjust_balance internes detectent leur cle individuelle et retournent
+-- l'etat existant -> on retourne le meme triplet (parent_tx, dep_tx, soldes).
+CREATE OR REPLACE FUNCTION transfer_to_dependent_central(
+  p_client_id        uuid,
+  p_building_id      uuid,
+  p_dep_external_id  text,
+  p_amount           numeric,
+  p_idempotency_key  text,
+  p_description      text DEFAULT NULL,
+  p_created_by       uuid DEFAULT NULL
+) RETURNS TABLE(
+  parent_transaction_id  uuid,
+  dep_transaction_id     uuid,
+  parent_balance_after   numeric,
+  dep_balance_after      numeric,
+  dep_id                 uuid,
+  idempotent_replay      boolean
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_parent_tx     uuid;
+  v_parent_bal    numeric;
+  v_parent_replay boolean;
+  v_dep_tx        uuid;
+  v_dep_bal       numeric;
+  v_dep_id        uuid;
+  v_dep_replay    boolean;
+BEGIN
+  IF p_dep_external_id IS NULL OR p_dep_external_id = '' THEN
+    RAISE EXCEPTION 'missing_dep_external_id'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'invalid_amount'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  IF p_idempotency_key IS NULL OR p_idempotency_key = '' THEN
+    RAISE EXCEPTION 'missing_idempotency_key'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- 1. Debit parent
+  SELECT t.transaction_id, t.virtual_balance, t.idempotent_replay
+    INTO v_parent_tx, v_parent_bal, v_parent_replay
+    FROM adjust_balance(
+      p_client_id       => p_client_id,
+      p_building_id     => p_building_id,
+      p_amount          => -p_amount,
+      p_type            => 'transfer_to_dependent',
+      p_reference_type  => 'transfer_to_dep',
+      p_description     => p_description,
+      p_idempotency_key => p_idempotency_key || ':out',
+      p_created_by      => p_created_by
+    ) t;
+
+  -- 2. Credit dependant
+  SELECT t.transaction_id, t.virtual_balance, t.dependent_id, t.idempotent_replay
+    INTO v_dep_tx, v_dep_bal, v_dep_id, v_dep_replay
+    FROM adjust_balance(
+      p_client_id       => p_client_id,
+      p_building_id     => p_building_id,
+      p_dep_external_id => p_dep_external_id,
+      p_amount          => p_amount,
+      p_type            => 'transfer_from_parent',
+      p_reference_type  => 'transfer_to_dep',
+      p_description     => p_description,
+      p_idempotency_key => p_idempotency_key || ':in',
+      p_created_by      => p_created_by
+    ) t;
+
+  parent_transaction_id := v_parent_tx;
+  dep_transaction_id    := v_dep_tx;
+  parent_balance_after  := v_parent_bal;
+  dep_balance_after     := v_dep_bal;
+  dep_id                := v_dep_id;
+  -- Replay = vrai ssi les deux jambes sont des replays (sinon c'est une
+  -- premiere ecriture mixte, considere comme nouvelle transaction).
+  idempotent_replay     := v_parent_replay AND v_dep_replay;
+  RETURN NEXT;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION transfer_to_dependent_central(uuid, uuid, text, numeric, text, text, uuid)
+  FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION transfer_to_dependent_central(uuid, uuid, text, numeric, text, text, uuid)
+  TO service_role;
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';

--- a/sql/015_finance_central_record_payment_relax_fk.sql
+++ b/sql/015_finance_central_record_payment_relax_fk.sql
@@ -1,0 +1,26 @@
+-- =====================================================================
+-- 015_finance_central_record_payment_relax_fk.sql
+-- Relaxe le FK real_payments.recorded_by -> auth.users(id) pour permettre
+-- a la fois :
+--   * l'admin modulimo-admin (auth.uid central) — comportement existant
+--   * l'admin de l'immeuble depuis CoHabitat (auth.uid cote building)
+-- L'identifiant reste un uuid : on garde la colonne en NOT NULL pour
+-- audit, mais on perd l'integrite referentielle puisqu'il vit dans deux
+-- bases distinctes. C'est acceptable pour un champ purement informatif —
+-- l'autorisation effective vient de finance-bridge (verification admin
+-- via le JWT cohabitat dans le handler /record-real-payment).
+-- =====================================================================
+
+BEGIN;
+
+ALTER TABLE real_payments DROP CONSTRAINT IF EXISTS real_payments_recorded_by_fkey;
+
+COMMENT ON COLUMN real_payments.recorded_by IS
+  'auth.uid de l''utilisateur ayant enregistre le paiement. Peut etre un
+  auth.users(id) central (admin modulimo-admin) ou un auth.users(id) du
+  Supabase de l''immeuble (admin CoHabitat passant via finance-bridge).
+  Pas de FK : l''integrite est garantie applicativement.';
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/functions/finance-bridge/handlers/record_real_payment.ts
+++ b/supabase/functions/finance-bridge/handlers/record_real_payment.ts
@@ -1,0 +1,163 @@
+// Endpoint POST /finance-bridge/record-real-payment : permet a l'admin de
+// l'immeuble (CoHabitat tab Admin > Paiements) de creer un credit virtuel
+// pour un resident contre un paiement reel recu (cash, virement, etc.) en
+// passant par la RPC centrale record_real_payment.
+//
+// Securite : le caller fournit son JWT CoHabitat (Bearer). On l'utilise
+// pour :
+//   1. Resoudre claims via le building_registry (existant)
+//   2. Verifier que le caller est admin de l'immeuble en lisant son
+//      profile.role via PostgREST cote building avec le meme JWT (RLS
+//      autorise un user a lire son propre profile).
+//   3. Resoudre le target user_id (fourni dans le body) -> client_id
+//      central via clients.cohabitat_user_id.
+//   4. Appeler record_real_payment(service_role) avec target_client_id.
+//
+// Le caller ne peut pas crediter quelqu'un en dehors de son propre
+// immeuble (find_client filtre par building_id) ni quelqu'un sans row
+// clients (404 explicite).
+
+import type { ResolvedClaims, BuildingRegistryEntry } from '../lib/types.ts';
+import type { CentralCaller } from '../lib/central.ts';
+
+const ADMIN_ROLES = new Set(['admin', 'principal_admin']);
+
+type FindClient = (cohabitatUserId: string, buildingId: string) =>
+  Promise<{ client_id: string } | null>;
+
+export interface RecordRealPaymentRequest {
+  target_user_id: string;        // cohabitat profiles.id du resident credite
+  amount_real: number;           // > 0
+  amount_virtual: number;        // > 0 (peut differ d'amount_real, p.ex. frais)
+  payment_method: 'cash' | 'transfer' | 'cheque' | 'credit_card' | 'debit_card' | 'other';
+  reference?: string | null;
+  notes?: string | null;
+  idempotency_key: string;
+}
+
+interface RpcRow {
+  transaction_id: string;
+  real_payment_id: string;
+  virtual_balance: number | string;
+  idempotent_replay: boolean;
+}
+
+export interface RecordRealPaymentResponse {
+  client_id: string;             // target client_id (le resident credite)
+  building_id: string;
+  transaction_id: string;
+  real_payment_id: string;
+  virtual_balance: number;
+  idempotent_replay: boolean;
+}
+
+async function fetchAdminRole(
+  buildingUrl: string,
+  cohabitatUserId: string,
+  bearerJwt: string,
+): Promise<string | null> {
+  const url = new URL('/rest/v1/profiles', buildingUrl);
+  url.searchParams.set('select', 'role');
+  url.searchParams.set('id', `eq.${cohabitatUserId}`);
+  url.searchParams.set('limit', '1');
+  // PostgREST cote building exige apikey. On reutilise le JWT du caller
+  // comme apikey ET Bearer — ca evite d'avoir besoin de la clé anon
+  // building dans finance-bridge. Le JWT user satisfait le PostgREST
+  // gateway (verifie la signature) puis la RLS autorise SELECT du propre
+  // profil.
+  const res = await fetch(url, {
+    headers: {
+      apikey: bearerJwt,
+      Authorization: `Bearer ${bearerJwt}`,
+    },
+  });
+  if (!res.ok) return null;
+  const rows = (await res.json()) as Array<{ role?: string }>;
+  return rows[0]?.role ?? null;
+}
+
+export async function handleRecordRealPayment(
+  claims: ResolvedClaims,
+  body: RecordRealPaymentRequest | null,
+  building: BuildingRegistryEntry,
+  callerJwt: string,
+  findClient: FindClient,
+  caller: CentralCaller,
+  serviceRole: string,
+): Promise<{
+  status: number;
+  body: RecordRealPaymentResponse | { error: string; detail?: unknown };
+}> {
+  if (!body) return { status: 400, body: { error: 'MISSING_BODY' } };
+  if (!body.target_user_id || typeof body.target_user_id !== 'string') {
+    return { status: 400, body: { error: 'MISSING_TARGET_USER_ID' } };
+  }
+  if (typeof body.amount_real !== 'number' || !Number.isFinite(body.amount_real) || body.amount_real <= 0) {
+    return { status: 400, body: { error: 'INVALID_AMOUNT_REAL' } };
+  }
+  if (typeof body.amount_virtual !== 'number' || !Number.isFinite(body.amount_virtual) || body.amount_virtual <= 0) {
+    return { status: 400, body: { error: 'INVALID_AMOUNT_VIRTUAL' } };
+  }
+  const validMethods = ['cash', 'transfer', 'cheque', 'credit_card', 'debit_card', 'other'];
+  if (!validMethods.includes(body.payment_method)) {
+    return { status: 400, body: { error: 'INVALID_PAYMENT_METHOD' } };
+  }
+  if (!body.idempotency_key || typeof body.idempotency_key !== 'string') {
+    return { status: 400, body: { error: 'MISSING_IDEMPOTENCY_KEY' } };
+  }
+
+  // 1. Verifier que le caller est admin de l'immeuble
+  const role = await fetchAdminRole(building.supabase_url, claims.cohabitat_user_id, callerJwt);
+  if (!role || !ADMIN_ROLES.has(role)) {
+    return { status: 403, body: { error: 'NOT_ADMIN', detail: { role } } };
+  }
+
+  // 2. Resoudre target_user_id -> target client_id (central)
+  const targetClient = await findClient(body.target_user_id, claims.building_id);
+  if (!targetClient) {
+    return { status: 404, body: { error: 'TARGET_CLIENT_NOT_FOUND' } };
+  }
+
+  // 3. Appeler record_real_payment
+  const res = await caller.callRpc<RpcRow[]>(
+    'record_real_payment',
+    {
+      p_client_id: targetClient.client_id,
+      p_building_id: claims.building_id,
+      p_amount_real: body.amount_real,
+      p_amount_virtual: body.amount_virtual,
+      p_payment_method: body.payment_method,
+      p_reference: body.reference ?? null,
+      p_notes: body.notes ?? null,
+      // recorded_by est l'auth.uid CoHabitat de l'admin. La FK sur
+      // auth.users(id) a ete relaxee dans sql/015 — c'est un champ
+      // d'audit sans FK, peut pointer cote building OU cote central.
+      p_recorded_by: claims.cohabitat_user_id,
+      p_idempotency_key: body.idempotency_key,
+    },
+    serviceRole,
+  );
+
+  if (!res.ok) {
+    const detail = res.body as { code?: string; message?: string } | undefined;
+    const code = detail?.code;
+    if (code === '22023') return { status: 400, body: { error: 'INVALID_PARAMETER', detail: res.body } };
+    if (code === '23505') return { status: 409, body: { error: 'IDEMPOTENCY_KEY_COLLISION', detail: res.body } };
+    return { status: 502, body: { error: 'CENTRAL_RPC_FAILED', detail: res.body } };
+  }
+
+  const row = Array.isArray(res.data) ? res.data[0] : null;
+  if (!row) return { status: 502, body: { error: 'CENTRAL_RPC_EMPTY' } };
+
+  return {
+    status: 200,
+    body: {
+      client_id: targetClient.client_id,
+      building_id: claims.building_id,
+      transaction_id: row.transaction_id,
+      real_payment_id: row.real_payment_id,
+      virtual_balance: Number(row.virtual_balance),
+      idempotent_replay: row.idempotent_replay,
+    },
+  };
+}

--- a/supabase/functions/finance-bridge/handlers/transfer.ts
+++ b/supabase/functions/finance-bridge/handlers/transfer.ts
@@ -1,0 +1,106 @@
+// Endpoint POST /finance-bridge/transfer-to-dep : transfere un montant
+// du solde principal du resident vers le solde d'un de ses dependants,
+// atomique cote central via la RPC transfer_to_dependent_central.
+//
+// Le resident agit sur LUI-MEME (claims.client_id == cible debit) et
+// designe le dependant via dependent_id (mappe a external_dep_id cote
+// central). Une seule cle d'idempotence cote client pilote les deux
+// jambes de l'ecriture (parent/dep) — la RPC en derive ":out" et ":in".
+
+import type { ResolvedClaims } from '../lib/types.ts';
+import type { CentralCaller } from '../lib/central.ts';
+
+export interface TransferToDepRequest {
+  client_id?: string;          // optionnel, doit matcher claims.client_id
+  dependent_id: string;        // external_dep_id (uuid CoHabitat dependents.id)
+  amount: number;              // strictement > 0
+  description?: string | null;
+  idempotency_key: string;     // unique par tentative de transfert
+}
+
+interface RpcRow {
+  parent_transaction_id: string;
+  dep_transaction_id: string;
+  parent_balance_after: number | string;
+  dep_balance_after: number | string;
+  dep_id: string;
+  idempotent_replay: boolean;
+}
+
+export interface TransferToDepResponse {
+  client_id: string;
+  building_id: string;
+  parent_transaction_id: string;
+  dep_transaction_id: string;
+  parent_balance_after: number;
+  dep_balance_after: number;
+  dep_id: string;
+  idempotent_replay: boolean;
+}
+
+export async function handleTransferToDep(
+  claims: ResolvedClaims,
+  body: TransferToDepRequest | null,
+  caller: CentralCaller,
+  serviceRole: string,
+): Promise<{
+  status: number;
+  body: TransferToDepResponse | { error: string; detail?: unknown };
+}> {
+  if (!body) return { status: 400, body: { error: 'MISSING_BODY' } };
+  if (body.client_id && body.client_id !== claims.client_id) {
+    return { status: 403, body: { error: 'CLIENT_ID_MISMATCH' } };
+  }
+  if (!body.dependent_id || typeof body.dependent_id !== 'string') {
+    return { status: 400, body: { error: 'MISSING_DEPENDENT_ID' } };
+  }
+  if (typeof body.amount !== 'number' || !Number.isFinite(body.amount) || body.amount <= 0) {
+    return { status: 400, body: { error: 'INVALID_AMOUNT' } };
+  }
+  if (!body.idempotency_key || typeof body.idempotency_key !== 'string') {
+    return { status: 400, body: { error: 'MISSING_IDEMPOTENCY_KEY' } };
+  }
+
+  const res = await caller.callRpc<RpcRow[]>(
+    'transfer_to_dependent_central',
+    {
+      p_client_id: claims.client_id,
+      p_building_id: claims.building_id,
+      p_dep_external_id: body.dependent_id,
+      p_amount: body.amount,
+      p_idempotency_key: body.idempotency_key,
+      p_description: body.description ?? null,
+      p_created_by: null,
+    },
+    serviceRole,
+  );
+
+  if (!res.ok) {
+    const detail = res.body as { code?: string; message?: string } | undefined;
+    const code = detail?.code;
+    const msg  = detail?.message ?? '';
+    if (code === '23514' || msg.includes('insufficient_funds')) {
+      return { status: 402, body: { error: 'INSUFFICIENT_FUNDS', detail: res.body } };
+    }
+    if (code === '22023') return { status: 400, body: { error: 'INVALID_PARAMETER', detail: res.body } };
+    if (code === '23505') return { status: 409, body: { error: 'IDEMPOTENCY_KEY_COLLISION', detail: res.body } };
+    return { status: 502, body: { error: 'CENTRAL_RPC_FAILED', detail: res.body } };
+  }
+
+  const row = Array.isArray(res.data) ? res.data[0] : null;
+  if (!row) return { status: 502, body: { error: 'CENTRAL_RPC_EMPTY' } };
+
+  return {
+    status: 200,
+    body: {
+      client_id: claims.client_id,
+      building_id: claims.building_id,
+      parent_transaction_id: row.parent_transaction_id,
+      dep_transaction_id: row.dep_transaction_id,
+      parent_balance_after: Number(row.parent_balance_after),
+      dep_balance_after: Number(row.dep_balance_after),
+      dep_id: row.dep_id,
+      idempotent_replay: row.idempotent_replay,
+    },
+  };
+}

--- a/supabase/functions/finance-bridge/index.ts
+++ b/supabase/functions/finance-bridge/index.ts
@@ -21,6 +21,8 @@ import { makePostgrestCaller } from './lib/central.ts';
 import { handleGetBalance } from './handlers/get_balance.ts';
 import { handleLunchPurchase } from './handlers/lunch_purchase.ts';
 import { handleDebit } from './handlers/debit.ts';
+import { handleTransferToDep } from './handlers/transfer.ts';
+import { handleRecordRealPayment } from './handlers/record_real_payment.ts';
 import { log, requestId } from './lib/logger.ts';
 
 const CORS_HEADERS: Record<string, string> = {
@@ -65,11 +67,13 @@ const deps = {
 const caller = makePostgrestCaller(CENTRAL_URL);
 
 // Liste blanche des endpoints exposes. Toute route inconnue retourne 404.
-type EndpointName = 'get-balance' | 'lunch-purchase' | 'debit';
+type EndpointName = 'get-balance' | 'lunch-purchase' | 'debit' | 'transfer-to-dep' | 'record-real-payment';
 const ENDPOINTS: Record<EndpointName, true> = {
   'get-balance': true,
   'lunch-purchase': true,
   'debit': true,
+  'transfer-to-dep': true,
+  'record-real-payment': true,
 };
 
 function extractEndpoint(pathname: string): EndpointName | null {
@@ -168,6 +172,44 @@ Deno.serve(async (req) => {
         building_id: resolved.claims.building_id,
         client_id: resolved.claims.client_id,
         type: (body as { type?: string } | null)?.type,
+        replay: (result.body as { idempotent_replay?: boolean }).idempotent_replay,
+      });
+      return json(result.body, result.status);
+    }
+    case 'transfer-to-dep': {
+      const result = await handleTransferToDep(
+        resolved.claims,
+        body as never,
+        caller,
+        SERVICE_ROLE,
+      );
+      log(result.status >= 500 ? 'error' : 'info', 'transfer_to_dep_done', {
+        rid,
+        endpoint,
+        status: result.status,
+        building_id: resolved.claims.building_id,
+        client_id: resolved.claims.client_id,
+        replay: (result.body as { idempotent_replay?: boolean }).idempotent_replay,
+      });
+      return json(result.body, result.status);
+    }
+    case 'record-real-payment': {
+      const result = await handleRecordRealPayment(
+        resolved.claims,
+        body as never,
+        resolved.building,
+        token,
+        deps.findClient,
+        caller,
+        SERVICE_ROLE,
+      );
+      log(result.status >= 500 ? 'error' : 'info', 'record_real_payment_done', {
+        rid,
+        endpoint,
+        status: result.status,
+        building_id: resolved.claims.building_id,
+        admin_user_id: resolved.claims.cohabitat_user_id,
+        target_user_id: (body as { target_user_id?: string } | null)?.target_user_id,
         replay: (result.body as { idempotent_replay?: boolean }).idempotent_replay,
       });
       return json(result.body, result.status);


### PR DESCRIPTION
## Contexte

Après avoir débloqué le débit lunch via `finance-bridge` (chsession handoff, mergé), il restait 2 chemins de mutation côté CoHabitat qui n'avaient **aucune** voie vers central :

- **Transfert parent → dépendant** : la RPC locale `transfer_to_dependent` est atomique sur cohabitat mais central n'en voit jamais trace.
- **Paiement admin** (`recordPayment`) : crédite localement avec `adjust_balance` mais central reste à zéro.

Cette PR ajoute les briques côté centrale pour que la PR jumelle CoHabitat puisse y router ces deux flows quand `finance_central_enabled=true`.

## Changements

### `sql/014_finance_central_transfer_to_dep.sql`

- Étend `transactions_type_check` avec `transfer_to_dependent` (débit parent) et `transfer_from_parent` (crédit dép). Le DROP cherche dynamiquement le nom dans `pg_constraint` pour résister aux variantes de naming auto.
- Nouvelle RPC `transfer_to_dependent_central(client, building, dep_external_id, amount, idem_key, description, created_by)` qui wrappe 2 `adjust_balance` internes dans la même transaction PG. Idempotency-keys dérivées `":out"` / `":in"` pour ne pas avoir de collision cross-leg.
- Atomicité garantie : si le crédit dép plante, le débit parent rollback. Pas de fenêtre où le parent perd sans que le dép reçoive.

### `sql/015_finance_central_record_payment_relax_fk.sql`

- Drop le FK `real_payments.recorded_by → auth.users(id)`. La colonne reste `NOT NULL`. Permet à un admin CoHabitat (auth.uid côté building) de figurer comme recorded_by sans être obligé d'exister sur l'instance Supabase centrale.

### `handlers/transfer.ts`

- `POST /finance-bridge/transfer-to-dep`. Body : `{ dependent_id, amount, description?, idempotency_key }`. Délègue à la RPC. Mapping erreurs : 402 INSUFFICIENT_FUNDS, 400 INVALID_PARAMETER, 409 IDEMPOTENCY_KEY_COLLISION, 502 sinon.

### `handlers/record_real_payment.ts`

- `POST /finance-bridge/record-real-payment`. Body : `{ target_user_id, amount_real, amount_virtual, payment_method, reference?, notes?, idempotency_key }`.
- **Auth en deux temps** :
  1. `resolveClaims` standard (JWT building → `building_registry` → caller's `client_id`)
  2. Fetch `/rest/v1/profiles?id=eq.<caller>&select=role` côté building avec le même JWT en `apikey + Bearer`. Vérifie `role IN ('admin', 'principal_admin')`. Sinon 403 NOT_ADMIN.
- Resolve `target_user_id` (cohabitat) → `target client_id` (central) via le `findClient` adapter existant (filtre par `building_id` automatiquement → impossible de créditer hors immeuble).
- Appelle `record_real_payment(service_role)` avec `p_recorded_by = claims.cohabitat_user_id`.

### `index.ts`

- Ajoute les 2 endpoints dans la whitelist + dispatcher.
- `record-real-payment` reçoit en plus `resolved.building` et le token raw (pour la vérif role).

## Déploiement

**Ordre obligatoire** :

1. `supabase db push` pour appliquer `sql/014` puis `sql/015`.
2. `supabase functions deploy finance-bridge` pour déployer les nouveaux handlers.
3. Merger la PR jumelle CoHabitat (qui appelle ces nouveaux endpoints).

Aucun nouveau secret env requis : `FINANCE_SERVICE_ROLE_KEY` existant suffit.

## Test plan

- [ ] `sql/014` + `sql/015` appliquées sans erreur.
- [ ] Edge function déployée sans warning.
- [ ] Depuis CoHabitat tab Profil > "Crédits" sur un dépendant : le transfert apparaît dans `central.transactions` (2 lignes : `transfer_to_dependent` parent + `transfer_from_parent` dep) et `central.balances` + `central.dependent_balances` reflètent les nouvelles valeurs.
- [ ] Idempotency : retry exact de la même requête → 200 avec `idempotent_replay: true`, pas de double mouvement.
- [ ] Depuis CoHabitat tab Admin > Paiements : enregistrer un paiement → `central.real_payments` créé, `central.balances` crédité, `central.transactions` ledger ligne `admin_credit`.
- [ ] Caller non-admin appelle `/record-real-payment` → 403 NOT_ADMIN.
- [ ] target_user_id d'un autre immeuble → 404 TARGET_CLIENT_NOT_FOUND.

https://claude.ai/code/session_014x1hCdnP2nKHd6vZ4pd8JM

---
_Generated by [Claude Code](https://claude.ai/code/session_014x1hCdnP2nKHd6vZ4pd8JM)_