### PR TITLE
Auto-provision clients dans finance-bridge (supprime le bouton Sync)

### DIFF
--- a/sql/016_finance_central_ensure_client.sql
+++ b/sql/016_finance_central_ensure_client.sql
@@ -1,0 +1,89 @@
+-- =====================================================================
+-- 016_finance_central_ensure_client.sql
+-- Auto-provisionnement des rows clients pour les residents qui ont un
+-- JWT valide d'un building actif mais pas encore de row clients. Ferme
+-- la derniere boucle de la migration solde central : avant cette RPC, un
+-- nouveau resident (ajoute apres le snapshot initial) etait flag
+-- "Non-sync" dans l'admin et le kiosque rejetait ses achats avec
+-- INSUFFICIENT_FUNDS (central avait 0). Avec cette RPC, finance-bridge
+-- cree la row clients automatiquement au premier appel.
+--
+-- Securite : SECURITY DEFINER + service_role only. La RPC verifie que
+-- le building cible est 'active' meme si finance-bridge le verifie deja
+-- en amont — defense en profondeur contre un appel direct service_role
+-- qui contournerait l'Edge Function.
+--
+-- Idempotence : INSERT...ON CONFLICT DO NOTHING (utilise l'index unique
+-- partiel idx_clients_cohabitat_per_building cree dans sql/007). Un
+-- 2eme appel sur le meme couple (cohabitat_user_id, building_id)
+-- retourne le client_id existant.
+-- =====================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION ensure_client(
+  p_cohabitat_user_id uuid,
+  p_building_id       uuid
+) RETURNS uuid
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_client_id uuid;
+BEGIN
+  IF p_cohabitat_user_id IS NULL OR p_building_id IS NULL THEN
+    RAISE EXCEPTION 'missing_params'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM building_registry
+     WHERE id = p_building_id AND status = 'active'
+  ) THEN
+    RAISE EXCEPTION 'building_not_active'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- Find first (frequent path post-provision : on evite l'INSERT inutile).
+  SELECT id INTO v_client_id
+    FROM clients
+   WHERE cohabitat_user_id = p_cohabitat_user_id
+     AND building_id       = p_building_id;
+  IF FOUND THEN
+    RETURN v_client_id;
+  END IF;
+
+  -- Create. Le ON CONFLICT cible l'index unique partiel pose en sql/007 :
+  -- idx_clients_cohabitat_per_building (building_id, cohabitat_user_id)
+  -- WHERE cohabitat_user_id IS NOT NULL AND building_id IS NOT NULL.
+  -- En cas de race (deux appels concurrents pour le meme resident),
+  -- le 2e tombe sur DO NOTHING + RETURNING vide -> on relit la row
+  -- gagnante.
+  INSERT INTO clients (cohabitat_user_id, building_id)
+  VALUES (p_cohabitat_user_id, p_building_id)
+  ON CONFLICT (building_id, cohabitat_user_id)
+    WHERE cohabitat_user_id IS NOT NULL AND building_id IS NOT NULL
+    DO NOTHING
+  RETURNING id INTO v_client_id;
+
+  IF v_client_id IS NULL THEN
+    SELECT id INTO v_client_id
+      FROM clients
+     WHERE cohabitat_user_id = p_cohabitat_user_id
+       AND building_id       = p_building_id;
+  END IF;
+
+  RETURN v_client_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION ensure_client(uuid, uuid)
+  FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION ensure_client(uuid, uuid) TO service_role;
+
+COMMENT ON FUNCTION ensure_client(uuid, uuid) IS
+  'Find-or-create d''une row clients pour un (cohabitat_user_id, building_id).
+  Appele par finance-bridge apres validation JWT pour eliminer le besoin de
+  provisioning manuel. Service_role only.';
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/functions/finance-bridge/index.ts
+++ b/supabase/functions/finance-bridge/index.ts
@@ -16,6 +16,7 @@ import {
   jwksResolverFor,
   makeFindBuildingByIssuer,
   makeFindClient,
+  makeProvisionClient,
 } from './lib/registry.ts';
 import { makePostgrestCaller } from './lib/central.ts';
 import { handleGetBalance } from './handlers/get_balance.ts';
@@ -61,6 +62,7 @@ log('info', 'finance_bridge_boot', {
 const deps = {
   findBuildingByIssuer: makeFindBuildingByIssuer(CENTRAL_URL, SERVICE_ROLE),
   findClient: makeFindClient(CENTRAL_URL, SERVICE_ROLE),
+  provisionClient: makeProvisionClient(CENTRAL_URL, SERVICE_ROLE),
   getKeyResolver: jwksResolverFor,
 };
 

--- a/supabase/functions/finance-bridge/lib/registry.ts
+++ b/supabase/functions/finance-bridge/lib/registry.ts
@@ -81,3 +81,49 @@ export function makeFindClient(
     return rows[0] ? { client_id: rows[0].id } : null;
   };
 }
+
+// Auto-provisionnement de la row clients via la RPC centrale ensure_client
+// (sql/016). Idempotente cote DB : un 2eme appel concurrent pour le meme
+// resident retourne la meme client_id. Retourne null si la RPC echoue
+// (building inactif, parametres invalides, panne reseau) — l'appelant
+// surface CLIENT_NOT_FOUND.
+export function makeProvisionClient(
+  centralUrl: string,
+  apiKey: string,
+): (cohabitatUserId: string, buildingId: string) => Promise<{ client_id: string } | null> {
+  return async (cohabitatUserId: string, buildingId: string) => {
+    const url = new URL('/rest/v1/rpc/ensure_client', centralUrl);
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        apikey: apiKey,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify({
+        p_cohabitat_user_id: cohabitatUserId,
+        p_building_id: buildingId,
+      }),
+    });
+    if (!res.ok) return null;
+    const text = await res.text();
+    if (!text) return null;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return null;
+    }
+    // PostgREST renvoie la valeur scalaire d'une RPC comme string brut
+    // (le uuid) ou parfois un objet { ensure_client: <uuid> } selon les
+    // versions. On gere les deux pour resilience.
+    let id: string | null = null;
+    if (typeof parsed === 'string') id = parsed;
+    else if (parsed && typeof parsed === 'object') {
+      const obj = parsed as Record<string, unknown>;
+      const v = obj.ensure_client;
+      if (typeof v === 'string') id = v;
+    }
+    return id ? { client_id: id } : null;
+  };
+}

--- a/supabase/functions/finance-bridge/lib/resolve.ts
+++ b/supabase/functions/finance-bridge/lib/resolve.ts
@@ -20,7 +20,19 @@ export type KeyResolver = Parameters<typeof jwtVerify>[1];
 export interface ResolveDeps {
   findBuildingByIssuer: (iss: string) => Promise<BuildingRegistryEntry | null>;
   getKeyResolver: (entry: BuildingRegistryEntry) => KeyResolver;
+  // Lookup strict : retourne null si la row clients n'existe pas. Garde sa
+  // semantique pour les appels qui veulent verifier l'existence sans creer
+  // (record-real-payment cible un user qui DOIT deja exister).
   findClient: (
+    cohabitatUserId: string,
+    buildingId: string,
+  ) => Promise<{ client_id: string } | null>;
+  // Find-or-create : appelee dans resolveClaims quand le JWT est valide
+  // pour un building actif mais que le caller n'a pas encore de row
+  // clients (resident ajoute apres la migration initiale). Doit etre
+  // idempotente cote DB. Retourne null seulement sur echec DB hard
+  // (que finance-bridge surface en CLIENT_NOT_FOUND).
+  provisionClient: (
     cohabitatUserId: string,
     buildingId: string,
   ) => Promise<{ client_id: string } | null>;
@@ -71,8 +83,15 @@ export async function resolveClaims(
   const sub = typeof verified.sub === 'string' ? verified.sub : null;
   if (!sub) return { ok: false, status: 401, error: 'MISSING_SUBJECT' };
 
-  const client = await deps.findClient(sub, building.id);
-  if (!client) return { ok: false, status: 403, error: 'CLIENT_NOT_FOUND' };
+  let client = await deps.findClient(sub, building.id);
+  if (!client) {
+    // Auto-provision : JWT valide + building actif = resident legitime,
+    // pas besoin d'attendre un bouton Sync manuel. La RPC centrale
+    // ensure_client est idempotente, donc une race entre deux requetes
+    // concurrentes pour le meme resident converge sur la meme client_id.
+    client = await deps.provisionClient(sub, building.id);
+    if (!client) return { ok: false, status: 403, error: 'CLIENT_NOT_FOUND' };
+  }
 
   return {
     ok: true,

--- a/supabase/functions/finance-bridge/tests/cross_tenant_test.ts
+++ b/supabase/functions/finance-bridge/tests/cross_tenant_test.ts
@@ -110,12 +110,47 @@ Deno.test('fuite #5 : immeuble suspendu => BUILDING_INACTIVE', async () => {
   if (!res.ok) assertEquals(res.error, 'BUILDING_INACTIVE');
 });
 
-Deno.test('fuite #6 : cohabitat_user_id sans row clients => CLIENT_NOT_FOUND', async () => {
-  const { buildingA, deps } = await setup();
-  const token = await signAsBuilding(buildingA, '99999999-9999-9999-9999-999999999999');
+Deno.test('fuite #6 : cohabitat_user_id sans row clients => auto-provisionne (sql/016)', async () => {
+  // Avant sql/016, ce scenario retournait CLIENT_NOT_FOUND et l'admin
+  // devait cliquer un bouton Sync manuel. Maintenant resolveClaims
+  // appelle ensure_client() qui INSERT la row si elle manque, et le
+  // resident peut transiger immediatement. La securite tient toujours :
+  // le JWT a deja ete verifie + le building est actif a ce stade.
+  const { buildingA, clients, deps } = await setup();
+  const newUser = '99999999-9999-9999-9999-999999999999';
+  const before = clients.length;
+  const token = await signAsBuilding(buildingA, newUser);
   const res = await resolveClaims(token, deps);
+  assertEquals(res.ok, true);
+  if (res.ok) {
+    assertEquals(res.claims.building_id, buildingA.entry.id);
+    assertEquals(res.claims.cohabitat_user_id, newUser);
+    // La row a bien ete pushee dans la table in-memory via le mock
+    // provisionClient — equivalent au INSERT cote DB en prod.
+    assertEquals(clients.length, before + 1);
+    const created = clients[clients.length - 1];
+    assertEquals(created.cohabitat_user_id, newUser);
+    assertEquals(created.building_id, buildingA.entry.id);
+    assertEquals(res.claims.client_id, created.client_id);
+  }
+});
+
+Deno.test('fuite #6b : provisionClient echoue (DB hard error) => CLIENT_NOT_FOUND', async () => {
+  // Cas degenere : la RPC ensure_client centrale renvoie null/erreur. On
+  // surface CLIENT_NOT_FOUND pour signaler clairement a l'appelant que
+  // l'auto-provision n'a pas marche, plutot que de masquer en 500.
+  const { buildingA, clients, deps } = await setup();
+  const failingDeps = {
+    ...deps,
+    provisionClient: async () => null,
+  };
+  const newUser = '88888888-8888-8888-8888-888888888888';
+  const before = clients.length;
+  const token = await signAsBuilding(buildingA, newUser);
+  const res = await resolveClaims(token, failingDeps);
   assertEquals(res.ok, false);
   if (!res.ok) assertEquals(res.error, 'CLIENT_NOT_FOUND');
+  assertEquals(clients.length, before);
 });
 
 Deno.test('fuite #7 : JWT expire => INVALID_SIGNATURE (jose rejette sur exp)', async () => {

--- a/supabase/functions/finance-bridge/tests/fixtures.ts
+++ b/supabase/functions/finance-bridge/tests/fixtures.ts
@@ -79,15 +79,26 @@ export async function signAsBuilding(
 // d'une table cohabitat_user_id -> client_id.
 export interface ResolveFixtures {
   buildings: BuildingFixture[];
+  // Pre-existing clients rows. Le tableau est mute par provisionClient
+  // (auto-provision) — par defaut, makeResolveDeps installe un
+  // provisionClient qui ajoute la nouvelle row dans ce tableau pour que
+  // les findClient ulterieurs la trouvent (mime le comportement DB
+  // post-INSERT).
   clients: Array<{
     cohabitat_user_id: string;
     building_id: string;
     client_id: string;
   }>;
+  // Si fourni, override le provisionClient default. Permet aux tests de
+  // simuler un echec DB (retourne null) sans avoir a forger une fonction
+  // entiere.
+  provisionClient?: ResolveDeps['provisionClient'];
 }
 
 export function makeResolveDeps(fx: ResolveFixtures): ResolveDeps {
   const byIssuer = new Map(fx.buildings.map((b) => [b.entry.jwt_issuer, b]));
+  const buildingActive = (buildingId: string) =>
+    fx.buildings.some((b) => b.entry.id === buildingId && b.entry.status === 'active');
   return {
     findBuildingByIssuer: async (iss) => {
       const b = byIssuer.get(iss);
@@ -104,6 +115,22 @@ export function makeResolveDeps(fx: ResolveFixtures): ResolveDeps {
       );
       return row ? { client_id: row.client_id } : null;
     },
+    provisionClient: fx.provisionClient ?? (async (cohabitatUserId, buildingId) => {
+      // Mime ensure_client cote DB : refus si building inactif, sinon
+      // INSERT...ON CONFLICT DO NOTHING + retour de la row gagnante.
+      if (!buildingActive(buildingId)) return null;
+      const existing = fx.clients.find(
+        (c) => c.cohabitat_user_id === cohabitatUserId && c.building_id === buildingId,
+      );
+      if (existing) return { client_id: existing.client_id };
+      const row = {
+        cohabitat_user_id: cohabitatUserId,
+        building_id: buildingId,
+        client_id: crypto.randomUUID(),
+      };
+      fx.clients.push(row);
+      return { client_id: row.client_id };
+    }),
   };
 }
 


### PR DESCRIPTION
## Contexte

Symptôme reporté en prod (Pointe Est) : Emy et Lucy ont des contrats actifs côté modulimo-admin et des soldes locaux non-nuls (1000 $ et 320 $), mais sont taggées **⚠ Non-sync** dans l'admin CoHabitat et le kiosque les rejette à l'achat avec `INSUFFICIENT_FUNDS`.

Cause : ces résidentes ont été créées **après** le `backfill-building-snapshot.ts` initial. Elles n'ont pas de row `central.clients`, donc :
- `finance-bridge/get-balance` → `CLIENT_NOT_FOUND` (caller flag Non-sync)
- `finance-bridge/lunch-purchase` ou `/debit` → même chose, central a 0

Workaround actuel : un bouton **🔗 Sync** côté CoHabitat que l'admin doit cliquer manuellement. C'est de la plomberie de migration exposée à l'utilisateur — alors que la règle métier est simple : **contrat actif = résident actif = peut transiger, point**. Aucun clic admin ne devrait être nécessaire.

## Changements

### `sql/016_finance_central_ensure_client.sql` (nouveau)

Nouvelle RPC `ensure_client(p_cohabitat_user_id uuid, p_building_id uuid) RETURNS uuid` :
- `SECURITY DEFINER` + `service_role` only
- Re-vérifie que `building_registry.status = 'active'` en défense en profondeur (un appel direct service_role bypassait sinon la vérif amont de finance-bridge)
- `INSERT...ON CONFLICT DO NOTHING` sur l'index unique partiel `idx_clients_cohabitat_per_building` (posé en sql/007), donc atomique en cas de race entre deux requêtes concurrentes pour le même résident
- Retourne le `client_id` (existant ou nouveau)

### `supabase/functions/finance-bridge/lib/registry.ts`

Nouvel adapter `makeProvisionClient(centralUrl, apiKey)` qui POST sur `/rest/v1/rpc/ensure_client` (apikey only, pas de Bearer — cohérent avec le pattern depuis la migration `sb_secret_*`).

### `supabase/functions/finance-bridge/lib/resolve.ts`

`ResolveDeps` gagne un `provisionClient`. Dans `resolveClaims`, après `findClient` qui retourne null, on appelle `provisionClient`. CLIENT_NOT_FOUND ne se produit plus que si la RPC échoue côté DB (panne réseau, building inactif, etc.) — sémantique d'erreur réelle, pas d'utilisateur "non provisionné".

`findClient` **strict est préservé** pour `record-real-payment` qui ne doit pas auto-provisionner un target inconnu (sinon un admin pourrait créditer un user qui n'existe pas).

### `supabase/functions/finance-bridge/index.ts`

Wiring du nouvel adapter dans `deps`.

### Tests (49/49 verts)

- **fuite #6 reformulée** : sans row clients → auto-provision réussit, le résident transige immédiatement. La row apparaît dans la table in-memory (mime le INSERT côté DB).
- **fuite #6b nouveau** : si la RPC `ensure_client` échoue, on surface `CLIENT_NOT_FOUND` comme avant (pas de masquage en 500).
- `tests/fixtures.ts` : `provisionClient` default mute le tableau `clients` pour que les `findClient` suivants trouvent la row (cohérent avec la sémantique DB post-INSERT).

## Déploiement

**Ordre obligatoire** :

1. `supabase db push` → applique `sql/016` sur la centrale
2. `supabase functions deploy finance-bridge` → déploie les nouveaux handlers

Aucun nouveau secret env requis : `FINANCE_SERVICE_ROLE_KEY` existant suffit.

## Test plan

- [ ] `sql/016` appliquée sans erreur, `\df ensure_client` retourne la signature
- [ ] Edge function déployée sans warning
- [ ] Côté Pointe Est : ouvrir le kiosque pour **Emy** depuis CoHabitat → l'achat passe (au lieu d'INSUFFICIENT_FUNDS)
- [ ] `central.clients` contient maintenant une row pour Emy avec `(cohabitat_user_id, building_id)` corrects
- [ ] Idem pour **Lucy** sur un autre flow (réservation espace ou kiosque)
- [ ] Le badge "⚠ Non-sync" disparaît après reload de l'admin (`loadTenants` retrouve la row dans `centralClientMap`)
- [ ] Régression Simon : achat normal continue de marcher (chemin `findClient` trouve la row, ne provisionne pas)
- [ ] Tests cross-tenant : un nouveau JWT d'un résident inconnu ne fait PAS apparaître la row chez un mauvais building (fuite #9 toujours OK)

## Suite (hors scope)

Une fois cette PR mergée et déployée, le bouton **🔗 Sync** + badge **⚠ Non-sync** + détection `centralClientMap` deviennent du code mort côté CoHabitat. PR distincte pour les retirer.

https://claude.ai/code/session_01Cb6YqXs9Ysdqc3wgfbuJ9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb6YqXs9Ysdqc3wgfbuJ9U)_