### PR TITLE
P3: ajoute lunch_cancel_refund a ALLOWED_REFUND_TYPES (finance-bridge)

### DIFF
--- a/supabase/functions/finance-bridge/handlers/debit.ts
+++ b/supabase/functions/finance-bridge/handlers/debit.ts
@@ -18,10 +18,19 @@ const ALLOWED_DEBIT_TYPES = [
 // Un user ne peut refund qu'une transaction existante qu'il a lui-meme
 // faite ; cela est garanti par le RLS + le reference_id fourni, pas
 // par cette fonction. On whitelist juste les types.
+//
+// lunch_cancel_refund : utilise par le kiosque LunchMachine (P3) quand
+// l'usager appuie "Annuler" en zone de cueillette apres une livraison
+// pre-debitee a confirmReservation. Le robot remet le plateau et
+// central recoit un refund idempotent qui annule le debit. La cle
+// d'idempotence cote client est 'lunch:refund:' + idempotency_key
+// d'origine, garantissant qu'un seul refund est applique meme si
+// cancelPickup est rejoue par l'outbox.
 const ALLOWED_REFUND_TYPES = [
   'space_cancel_refund',
   'trip_cancel_refund',
   'trip_driver_earning',
+  'lunch_cancel_refund',
 ] as const;
 
 type AllowedType =

--- a/supabase/functions/finance-bridge/handlers/health.ts
+++ b/supabase/functions/finance-bridge/handlers/health.ts
@@ -1,0 +1,54 @@
+// Endpoint /health : ping infrastructure pour que les clients sachent si
+// la centrale est joignable AVANT d'engager une transaction (achat lunch,
+// reservation espace, etc.). Pas d'authentification : la reponse ne
+// revele rien de sensible (juste "central up/down" + latence).
+//
+// L'idee est qu'un client (CoHabitat, kiosque LunchMachine) poll cet
+// endpoint toutes les ~60 s + au boot + sur l'evenement window 'online',
+// et grise les boutons d'action quand la reponse n'est pas ok. Ca evite
+// qu'un usager se retrouve avec un plat livre sans debit, ou une
+// reservation creee localement sans contrepartie centrale.
+
+import type { CentralCaller } from '../lib/central.ts';
+
+export interface HealthOkResponse {
+  ok: true;
+  latency_ms: number;
+  ts: string;
+}
+
+export interface HealthErrorResponse {
+  ok: false;
+  error: string;
+  latency_ms?: number;
+  detail?: unknown;
+}
+
+export async function handleHealth(
+  caller: CentralCaller,
+  serviceRole: string,
+): Promise<{ status: number; body: HealthOkResponse | HealthErrorResponse }> {
+  if (!serviceRole) {
+    return { status: 503, body: { ok: false, error: 'SERVICE_ROLE_MISSING' } };
+  }
+  const res = await caller.ping(serviceRole);
+  if (!res.ok) {
+    return {
+      status: 503,
+      body: {
+        ok: false,
+        error: 'CENTRAL_UNREACHABLE',
+        latency_ms: res.latency_ms,
+        detail: { status: res.status, message: res.error ?? null },
+      },
+    };
+  }
+  return {
+    status: 200,
+    body: {
+      ok: true,
+      latency_ms: res.latency_ms,
+      ts: new Date().toISOString(),
+    },
+  };
+}

--- a/supabase/functions/finance-bridge/index.ts
+++ b/supabase/functions/finance-bridge/index.ts
@@ -24,11 +24,12 @@ import { handleLunchPurchase } from './handlers/lunch_purchase.ts';
 import { handleDebit } from './handlers/debit.ts';
 import { handleTransferToDep } from './handlers/transfer.ts';
 import { handleRecordRealPayment } from './handlers/record_real_payment.ts';
+import { handleHealth } from './handlers/health.ts';
 import { log, requestId } from './lib/logger.ts';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
   'Access-Control-Allow-Headers': 'authorization, content-type, apikey, x-client-info, idempotency-key',
   'Access-Control-Max-Age': '86400',
 };
@@ -69,14 +70,19 @@ const deps = {
 const caller = makePostgrestCaller(CENTRAL_URL);
 
 // Liste blanche des endpoints exposes. Toute route inconnue retourne 404.
-type EndpointName = 'get-balance' | 'lunch-purchase' | 'debit' | 'transfer-to-dep' | 'record-real-payment';
+// `health` est public (pas de Bearer requis) car il sert au probing cote
+// client pour decider si l'UI doit verrouiller les actions transactionnelles.
+type EndpointName = 'get-balance' | 'lunch-purchase' | 'debit' | 'transfer-to-dep' | 'record-real-payment' | 'health';
 const ENDPOINTS: Record<EndpointName, true> = {
   'get-balance': true,
   'lunch-purchase': true,
   'debit': true,
   'transfer-to-dep': true,
   'record-real-payment': true,
+  'health': true,
 };
+const PUBLIC_ENDPOINTS: ReadonlySet<EndpointName> = new Set(['health']);
+const GET_ENDPOINTS:    ReadonlySet<EndpointName> = new Set(['health']);
 
 function extractEndpoint(pathname: string): EndpointName | null {
   const parts = pathname.split('/').filter(Boolean);
@@ -88,11 +94,34 @@ function extractEndpoint(pathname: string): EndpointName | null {
 Deno.serve(async (req) => {
   const rid = requestId();
   if (req.method === 'OPTIONS') return new Response(null, { headers: CORS_HEADERS });
-  if (req.method !== 'POST') return json({ error: 'METHOD_NOT_ALLOWED', rid }, 405);
 
   const url = new URL(req.url);
   const endpoint = extractEndpoint(url.pathname);
   if (!endpoint) return json({ error: 'UNKNOWN_ENDPOINT', rid }, 404);
+
+  const isPublic = PUBLIC_ENDPOINTS.has(endpoint);
+  const allowGet = GET_ENDPOINTS.has(endpoint);
+  if (req.method === 'GET' && !allowGet) {
+    return json({ error: 'METHOD_NOT_ALLOWED', rid }, 405);
+  }
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    return json({ error: 'METHOD_NOT_ALLOWED', rid }, 405);
+  }
+
+  // Endpoint public : pas de resolution JWT, pas de body parsing.
+  // Court-circuit pour le health-check.
+  if (isPublic && endpoint === 'health') {
+    if (!SERVICE_ROLE) {
+      log('error', 'service_role_missing', { rid, endpoint });
+      return json({ ok: false, error: 'SERVICE_ROLE_MISSING', rid }, 503);
+    }
+    const result = await handleHealth(caller, SERVICE_ROLE);
+    log(result.status >= 500 ? 'warn' : 'info', 'health_done', {
+      rid, endpoint, status: result.status,
+      latency_ms: (result.body as { latency_ms?: number }).latency_ms,
+    });
+    return json(result.body, result.status);
+  }
 
   const auth = req.headers.get('authorization') ?? '';
   const m = auth.match(/^Bearer\s+(.+)$/i);
@@ -215,6 +244,11 @@ Deno.serve(async (req) => {
         replay: (result.body as { idempotent_replay?: boolean }).idempotent_replay,
       });
       return json(result.body, result.status);
+    }
+    default: {
+      // health est court-circuite plus haut ; tout autre endpoint manquant
+      // serait un bug de routage.
+      return json({ error: 'ENDPOINT_NOT_HANDLED', rid, endpoint }, 500);
     }
   }
 });

--- a/supabase/functions/finance-bridge/lib/central.ts
+++ b/supabase/functions/finance-bridge/lib/central.ts
@@ -13,11 +13,22 @@ export interface CentralCaller {
     params: Record<string, unknown>,
     apiKey: string,
   ): Promise<CentralRpcResult<T>>;
+  // Ping leger pour le health-check : verifie que PostgREST + DB centrale
+  // repondent. Utilise par /health pour que les clients sachent si la
+  // centrale est joignable avant d'engager une transaction.
+  ping(apiKey: string): Promise<CentralPingResult>;
 }
 
 export type CentralRpcResult<T> =
   | { ok: true; data: T }
   | { ok: false; status: number; error: string; body?: unknown };
+
+export interface CentralPingResult {
+  ok: boolean;
+  status: number;
+  latency_ms: number;
+  error?: string;
+}
 
 export function makePostgrestCaller(centralUrl: string): CentralCaller {
   return {
@@ -47,6 +58,33 @@ export function makePostgrestCaller(centralUrl: string): CentralCaller {
         return { ok: false, status: res.status, error: 'RPC_FAILED', body };
       }
       return { ok: true, data: body as T };
+    },
+    async ping(apiKey: string): Promise<CentralPingResult> {
+      // Ping = HEAD sur building_registry avec limit=1. C'est la requete la
+      // plus legere qui verifie en meme temps : PostgREST repond, l'apikey
+      // est valide, la DB est joignable. Pas de body retourne, juste les
+      // headers Content-Range. Timeout court pour ne pas bloquer le client.
+      const url = new URL('/rest/v1/building_registry', centralUrl);
+      url.searchParams.set('select', 'id');
+      url.searchParams.set('limit', '1');
+      const t0 = performance.now();
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), 3000);
+      try {
+        const res = await fetch(url, {
+          method: 'HEAD',
+          headers: { apikey: apiKey },
+          signal: ctrl.signal,
+        });
+        const latency_ms = Math.round(performance.now() - t0);
+        return { ok: res.ok, status: res.status, latency_ms };
+      } catch (err) {
+        const latency_ms = Math.round(performance.now() - t0);
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false, status: 0, latency_ms, error: message };
+      } finally {
+        clearTimeout(timer);
+      }
     },
   };
 }

--- a/supabase/functions/finance-bridge/tests/health_test.ts
+++ b/supabase/functions/finance-bridge/tests/health_test.ts
@@ -1,0 +1,50 @@
+// Tests du handler /health avec un CentralCaller fake.
+// Valide : ok quand ping ok, 503 quand ping ko, 503 quand service_role manque.
+
+import { assertEquals } from './_assert.ts';
+import { handleHealth } from '../handlers/health.ts';
+import type { CentralCaller, CentralPingResult, CentralRpcResult } from '../lib/central.ts';
+
+function fakeCaller(ping: () => CentralPingResult): CentralCaller {
+  return {
+    async callRpc<T>(): Promise<CentralRpcResult<T>> {
+      throw new Error('callRpc ne devrait pas etre appele par /health');
+    },
+    async ping() {
+      return ping();
+    },
+  };
+}
+
+Deno.test('health : 200 quand ping ok', async () => {
+  const caller = fakeCaller(() => ({ ok: true, status: 200, latency_ms: 17 }));
+  const out = await handleHealth(caller, 'sb_secret_xxx');
+  assertEquals(out.status, 200);
+  const body = out.body as { ok: boolean; latency_ms: number };
+  assertEquals(body.ok, true);
+  assertEquals(body.latency_ms, 17);
+});
+
+Deno.test('health : 503 quand ping ko', async () => {
+  const caller = fakeCaller(() => ({
+    ok: false,
+    status: 0,
+    latency_ms: 3001,
+    error: 'aborted',
+  }));
+  const out = await handleHealth(caller, 'sb_secret_xxx');
+  assertEquals(out.status, 503);
+  const body = out.body as { ok: boolean; error: string; latency_ms?: number };
+  assertEquals(body.ok, false);
+  assertEquals(body.error, 'CENTRAL_UNREACHABLE');
+  assertEquals(body.latency_ms, 3001);
+});
+
+Deno.test('health : 503 quand service_role absent', async () => {
+  const caller = fakeCaller(() => ({ ok: true, status: 200, latency_ms: 5 }));
+  const out = await handleHealth(caller, '');
+  assertEquals(out.status, 503);
+  const body = out.body as { ok: boolean; error: string };
+  assertEquals(body.ok, false);
+  assertEquals(body.error, 'SERVICE_ROLE_MISSING');
+});


### PR DESCRIPTION
## Summary
Ajoute `lunch_cancel_refund` à la whitelist `ALLOWED_REFUND_TYPES` dans `finance-bridge/handlers/debit.ts`. Nécessaire pour que le kiosque LunchMachine puisse refunder un pré-débit quand l'usager annule en zone de cueillette (cancelPickup).

## Détails
- Le refund passe par `/finance-bridge/debit` avec `amount > 0` et `type='lunch_cancel_refund'`
- Crée une transaction de crédit qui compense le débit initial fait par `lunch_purchase` à `confirmReservation`
- La clé d'idempotence côté client est `'lunch:refund:' + idempotency_key` d'origine, garantissant qu'un retry de l'outbox ne refunde pas en double
- Le `lunch_audit` du purchase original reste pour la traçabilité

## Note inclut aussi le commit P1 health endpoint
Cette branche contient aussi le commit P1 (`finance-bridge/health` endpoint) qui n'avait pas été mergé via PR — il était déployé manuellement via supabase CLI. Le merge formalise l'historique sur `main`.

## Test plan
- [ ] Déployer la fonction `finance-bridge` après merge
- [ ] Tester un cycle complet sur LunchMachine : achat → robot livre → CANCEL → vérifier que le solde est restauré côté central
- [ ] Vérifier qu'un refund retenté avec le même `idempotency_key` retourne `idempotent_replay: true` sans double-créditer

https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q)_