### PR TITLE
P3 fix: desactive verify_jwt sur finance-bridge (gateway laisse passer /health)

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,22 @@
+# Supabase project config — modulimo-admin (centrale Modulimo)
+# Lu par la CLI au moment de `supabase functions deploy`. Limite a la
+# config strictement necessaire ; le reste reste sur les defauts.
+
+project_id = "bpxscgrbxjscicpnheep"
+
+# ── Edge Functions ────────────────────────────────────────────────────
+# verify_jwt = false desactive la verification JWT au niveau du gateway
+# Supabase pour cette fonction. Necessaire car :
+#   1. /health doit etre joignable sans auth (probe client). Avec
+#      verify_jwt=true, le gateway repond 401 avant que le code
+#      n'execute le short-circuit public.
+#   2. Les endpoints proteges (/get-balance, /lunch-purchase, /debit,
+#      /transfer-to-dep, /record-real-payment) signent les JWT avec la
+#      cle de l'immeuble appelant (Auth Supabase de cohabitat), pas
+#      avec la cle JWT du projet central. Donc le gateway central ne
+#      peut PAS valider ces JWT — la verification est faite par le
+#      code de la fonction (resolve.ts) via JWKS distantes.
+# La fonction enforce l'auth elle-meme : seul /health est public, tous
+# les autres endpoints rejettent les requetes sans Bearer valide.
+[functions.finance-bridge]
+verify_jwt = false


### PR DESCRIPTION
## Summary
Le gateway Supabase enforce JWT au niveau gateway par défaut, ce qui empêche le probe client de joindre `/health` (rejeté avec `UNAUTHORIZED_NO_AUTH_HEADER` ou `UNAUTHORIZED_INVALID_JWT_FORMAT`). Désactive `verify_jwt` pour `finance-bridge` via `supabase/config.toml`.

## Pourquoi c'est sûr
- Seul `/health` est public dans le code de la fonction (short-circuit avant `resolveClaims`)
- Les autres endpoints (`/get-balance`, `/lunch-purchase`, `/debit`, `/transfer-to-dep`, `/record-real-payment`) rejettent toute requête sans Bearer valide via `MISSING_BEARER` puis valident le JWT contre les JWKS des immeubles (signatures par bâtiment, pas par le central — donc le gateway central ne peut pas valider de toute façon)

## Test plan
- [ ] Après déploiement : `curl https://.../finance-bridge/health -H "apikey: sb_publishable_..."` doit renvoyer 200 ok
- [ ] Vérifier que les endpoints protégés rejettent toujours sans Bearer (test : appeler `/get-balance` sans Authorization → doit renvoyer 401 `MISSING_BEARER`)

https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q)_