### PR TITLE
Fix export_client_data_central : retire signature_tokens (table inexistante)

### DIFF
--- a/sql/017_export_client_data_central.sql
+++ b/sql/017_export_client_data_central.sql
@@ -98,13 +98,10 @@ BEGIN
       WHERE lt.client_id = p_client_id
     ), '[]'::jsonb),
 
-    -- Tokens de signature emis pour ce client (contrats signes ou en
-    -- attente). Skip silencieusement si la table n'existe pas.
-    'signature_tokens',      COALESCE((
-      SELECT jsonb_agg(to_jsonb(st))
-      FROM signature_tokens st
-      WHERE st.client_id = p_client_id
-    ), '[]'::jsonb),
+    -- Note : pas de table signature_tokens — les colonnes
+    -- signature_token / signature_token_expires_at vivent directement
+    -- sur la table contracts (cf sql/001_signature_tokens.sql), donc
+    -- deja couvertes par 'contracts' ci-dessus.
 
     -- Log des divergences soldes (si l'immeuble a synchronise des
     -- valeurs locales differentes des valeurs centrales pour ce client)


### PR DESCRIPTION
Suite à `42P01: relation "signature_tokens" does not exist` — il n'y a pas de table `signature_tokens`. La signature des contrats est stockée dans des colonnes sur la table `contracts` (`signature_token`, `signature_token_expires_at`, etc.) — voir `sql/001_signature_tokens.sql`. L'info est donc déjà couverte par la section `contracts` de l'export.

Retrait de la section orpheline.

https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q)_