### PR TITLE
Affiche identite d'origine sur les rows clients anonymises

### DIFF
--- a/index.html
+++ b/index.html
@@ -931,6 +931,32 @@ async function loadClients() {
   const { data } = await sb.from('clients').select('*').order('created_at', { ascending: true });
   clientsCache = data || [];
 
+  // Joint avec les certificats pour afficher l'identite d'origine sur
+  // les rows anonymisees (sinon "Resident anonyme #X" sans contexte
+  // est tres peu pratique pour un admin qui scanne la liste).
+  // L'expose seulement aux admins authentifies (RLS sur la table).
+  const anonIds = clientsCache.filter(c => c.anonymized_at).map(c => c.id);
+  let certMap = {};
+  if (anonIds.length) {
+    const { data: certs } = await sb.from('anonymization_certificates')
+      .select('client_id, subject_name, subject_unit, building_name')
+      .in('client_id', anonIds);
+    (certs || []).forEach(ct => { certMap[ct.client_id] = ct; });
+  }
+
+  // Annote les clients avec leurs certs pour que les helpers puissent
+  // construire la string "ex: Lucy B — Pointe-Est, Unite 1".
+  function _anonOriginLabel(c) {
+    const ct = certMap[c.id];
+    if (!ct) return '';
+    const parts = [];
+    if (ct.subject_name) parts.push(ct.subject_name);
+    const loc = [ct.building_name, ct.subject_unit].filter(Boolean).join(' · ');
+    if (loc) parts.push(loc);
+    if (!parts.length) return '';
+    return ' <span style="font-size:11px;color:var(--text3);font-style:italic;font-weight:400;">(ex: ' + parts.join(' — ') + ')</span>';
+  }
+
   const owners = clientsCache.filter(c => c.client_type === 'owner');
   const tenants = clientsCache.filter(c => c.client_type !== 'owner');
 
@@ -961,7 +987,7 @@ async function loadClients() {
     const modStr = [mods.spaces?'🏠':'', mods.trips?'🚗':'', mods.lunch?'🍱':''].filter(Boolean).join(' ') || '—';
     const rowStyle = o.anonymized_at ? 'opacity:.55;background:rgba(120,120,120,.04)' : 'background:rgba(200,169,110,.04)';
     rows.push(`<tr style="${rowStyle}">
-      <td><strong>🏢 ${o.name}</strong>${o.is_admin ? ' <span class="badge badge-yellow" style="font-size:10px;">Admin</span>' : ''}</td>
+      <td><strong>🏢 ${o.name}</strong>${o.is_admin ? ' <span class="badge badge-yellow" style="font-size:10px;">Admin</span>' : ''}${_anonOriginLabel(o)}</td>
       <td><span class="badge badge-gray">Propriétaire</span></td>
       <td>${_statusBadge(o)}</td>
       <td style="font-size:12px">${o.contact_name ? '<strong>' + o.contact_name + '</strong><br>' : ''}${o.contact_email || '—'}</td>
@@ -975,7 +1001,7 @@ async function loadClients() {
       const modStr2 = [mods2.spaces?'🏠':'', mods2.trips?'🚗':'', mods2.lunch?'🍱':''].filter(Boolean).join(' ') || '—';
       const tStyle = t.anonymized_at ? 'opacity:.55' : '';
       rows.push(`<tr style="${tStyle}">
-        <td style="padding-left:32px;color:var(--text2)">↳ ${t.name}</td>
+        <td style="padding-left:32px;color:var(--text2)">↳ ${t.name}${_anonOriginLabel(t)}</td>
         <td><span class="badge badge-gray">${typeLabel}</span></td>
         <td>${_statusBadge(t)}</td>
         <td style="font-size:12px">${t.contact_name ? '<strong>' + t.contact_name + '</strong><br>' : ''}${t.contact_email || '—'}</td>
@@ -994,7 +1020,7 @@ async function loadClients() {
       const modStr2 = [mods2.spaces?'🏠':'', mods2.trips?'🚗':'', mods2.lunch?'🍱':''].filter(Boolean).join(' ') || '—';
       const orphStyle = t.anonymized_at ? 'opacity:.55' : '';
       rows.push(`<tr style="${orphStyle}">
-        <td style="color:var(--text2)">${t.name}</td>
+        <td style="color:var(--text2)">${t.name}${_anonOriginLabel(t)}</td>
         <td><span class="badge badge-gray">${typeLabel}</span></td>
         <td>${_statusBadge(t)}</td>
         <td style="font-size:12px">${t.contact_name ? '<strong>' + t.contact_name + '</strong><br>' : ''}${t.contact_email || '—'}</td>


### PR DESCRIPTION
Option (B) du compromis Loi 25 : pour faciliter le scan admin, on expose l'identité originale (nom + immeuble + unité) en italique gris à côté du label anonyme dans la liste clients.

Format affiché :
```
Resident anonyme #29672369  (ex: Lucy B — Pointe-Est · Unité 1)
```

## Sécurité
- Données lues depuis `anonymization_certificates` via RLS (SELECT autorisé pour `authenticated` uniquement = admins Modulimo)
- Pas d'exposition tiers — juste un confort UI pour les admins qui doivent retrouver un ancien locataire (litige TAL, audit CAI)
- Loi 25 art. 21 : usage légitime pour preuve de conformité

## Implémentation
- `loadClients()` fait une 2e requête vers `anonymization_certificates` filtrée sur les `client_id` anonymisés
- Helper `_anonOriginLabel(c)` construit la string italique
- Annotation appliquée aux 3 cas : owners, tenants children, orphans

https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q)_