### PR TITLE
Phase H Loi 25 : garde-fou anti re-creation de client anonymise

### DIFF
--- a/index.html
+++ b/index.html
@@ -2781,9 +2781,14 @@ async function editClient(c) {
 }
 
 // Loi 25 — Edge Function loi25-process pour export et anonymisation.
-async function _loi25Call(action, clientId) {
+// Helper d'appel a l'Edge Function loi25-process. Le 2eme argument est :
+//   - une string UUID pour les endpoints client_id (export, anonymize, certificate)
+//   - un objet { name } pour /lookup
+//   - n'importe quel objet pour des extensions futures
+async function _loi25Call(action, arg) {
   const { data: { session } } = await sb.auth.getSession();
   if (!session?.access_token) throw new Error('Session admin requise');
+  const body = (typeof arg === 'string') ? { client_id: arg } : (arg || {});
   const res = await fetch(CENTRAL_URL + '/functions/v1/loi25-process/' + action, {
     method: 'POST',
     headers: {
@@ -2791,7 +2796,7 @@ async function _loi25Call(action, clientId) {
       'apikey': CENTRAL_KEY,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({ client_id: clientId })
+    body: JSON.stringify(body)
   });
   const json = await res.json().catch(() => null);
   if (!res.ok) throw new Error((json && json.error) || ('HTTP ' + res.status));
@@ -3192,6 +3197,31 @@ async function saveClient() {
     updated_at: new Date().toISOString()
   };
   if (!payload.name) { toast('Nom requis', 'error'); return; }
+
+  // Garde-fou Loi 25 : si on cree un nouveau client, verifier qu'il n'existe
+  // pas deja un certificat d'anonymisation pour ce nom. Eviter de re-creer un
+  // compte pour quelqu'un qui a demande l'effacement (prevention de fraude /
+  // ambiguite admin).
+  if (!id) {
+    try {
+      const r = await _loi25Call('lookup', { name: payload.name });
+      const matches = (r && r.result && r.result.matches) || [];
+      if (matches.length > 0) {
+        const m = matches[0];
+        const d = m.anonymized_at ? new Date(m.anonymized_at).toLocaleDateString('fr-CA') : '?';
+        const loc = [m.building_name, m.subject_unit].filter(Boolean).join(' · ');
+        const msg = '⚠ Une personne portant ce nom a deja ete anonymisee :\n\n'
+          + '   ' + m.subject_name + (loc ? ' — ' + loc : '') + '\n'
+          + '   Anonymisee le ' + d + ' par ' + (m.admin_email || 'admin')
+          + (matches.length > 1 ? '\n   (+' + (matches.length - 1) + ' autre' + (matches.length > 2 ? 's' : '') + ' match' + (matches.length > 2 ? 'es' : '') + ')' : '')
+          + '\n\nCreer quand meme un nouveau compte ?';
+        if (!confirm(msg)) return;
+      }
+    } catch (e) {
+      // Si le lookup plante (pas critique), on continue mais on log.
+      console.warn('[saveClient] lookup loi25 failed:', e && e.message);
+    }
+  }
 
   if (id) {
     // Modification

--- a/sql/021_lookup_anonymization_by_name.sql
+++ b/sql/021_lookup_anonymization_by_name.sql
@@ -1,0 +1,60 @@
+-- 021_lookup_anonymization_by_name.sql
+-- Garde-fou : avant de creer un nouveau client, l'admin peut verifier
+-- si un certificat d'anonymisation existe pour ce nom (typiquement
+-- "ancien locataire revient apres anonymisation").
+--
+-- Usage Loi 25 art. 4 (minimisation) : utilisation legitime de la
+-- preuve d'anonymisation pour prevenir les ambiguites administratives,
+-- pas pour fishing. La RPC retourne des matches exacts seulement
+-- (ILIKE p_name complet, pas LIKE '%query%').
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION lookup_anonymization_by_name(p_name TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_normalized TEXT;
+BEGIN
+  IF p_name IS NULL OR length(trim(p_name)) < 3 THEN
+    -- Refuse les requetes trop vagues (eviter fishing).
+    RETURN jsonb_build_object('ok', true, 'matches', '[]'::jsonb);
+  END IF;
+
+  v_normalized := lower(trim(p_name));
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'matches', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'certificate_id',  ac.id,
+        'client_id',       ac.client_id,
+        'subject_name',    ac.subject_name,
+        'subject_unit',    ac.subject_unit,
+        'building_name',   ac.building_name,
+        'anonymized_at',   ac.anonymized_at,
+        'admin_email',     ac.admin_email
+      ) ORDER BY ac.anonymized_at DESC)
+      FROM anonymization_certificates ac
+      WHERE lower(trim(ac.subject_name)) = v_normalized
+    ), '[]'::jsonb)
+  );
+END;
+$fn$;
+
+REVOKE ALL ON FUNCTION lookup_anonymization_by_name(TEXT)
+  FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION lookup_anonymization_by_name(TEXT) TO service_role;
+
+COMMENT ON FUNCTION lookup_anonymization_by_name(TEXT) IS
+  'Loi 25 garde-fou : retourne les certificats d''anonymisation
+  matchant exactement un nom donne. Usage par les admins pour eviter
+  de re-creer un compte pour une personne deja anonymisee. Match
+  exact (lower+trim), pas de fuzzy/fishing.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/functions/loi25-process/index.ts
+++ b/supabase/functions/loi25-process/index.ts
@@ -113,7 +113,7 @@ Deno.serve(async (req) => {
   const admin = await resolveAdmin(adminToken);
   if (!admin.ok) return json({ ok: false, error: admin.error }, 401);
 
-  let body: { client_id?: string } = {};
+  let body: { client_id?: string; name?: string } = {};
   try {
     if ((req.headers.get('content-type') ?? '').includes('application/json')) {
       body = await req.json();
@@ -122,6 +122,23 @@ Deno.serve(async (req) => {
     return json({ ok: false, error: 'INVALID_JSON' }, 400);
   }
 
+  // /lookup prend un name au lieu d'un client_id (cas : verifier si un
+  // nom donne correspond a un certificat d'anonymisation existant).
+  if (endpoint === 'lookup') {
+    const name = (body.name || '').trim();
+    if (!name || name.length < 3) {
+      return json({ ok: false, error: 'NAME_TOO_SHORT', detail: 'Au moins 3 caracteres requis' }, 400);
+    }
+    const r = await callRpc('lookup_anonymization_by_name', { p_name: name });
+    if (!r.ok) {
+      console.error('[loi25-process] lookup failed', r);
+      return json({ ok: false, error: 'CENTRAL_RPC_FAILED', detail: r.body }, 502);
+    }
+    console.info('[loi25-process] lookup', { admin: admin.email, name });
+    return json({ ok: true, action: 'lookup', result: r.data });
+  }
+
+  // Tous les autres endpoints exigent un client_id valide.
   const clientId = body.client_id?.trim();
   if (!clientId || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(clientId)) {
     return json({ ok: false, error: 'INVALID_CLIENT_ID' }, 400);


### PR DESCRIPTION
## Phase H Loi 25 — Garde-fou anti re-création
Avant de créer un nouveau client, l'admin est alerté si un certificat d'anonymisation existe pour ce nom. Permet de :
- Éviter les ambiguïtés administratives (ancien locataire qui revient)
- Prévenir la fraude légère (anonymisation pour effacer des dettes puis recréation)
- Conserver la cohérence avec Loi 25 art. 4 (minimisation + finalité)

## Implémentation

### `sql/021_lookup_anonymization_by_name.sql`
- RPC `lookup_anonymization_by_name(p_name)`
- Match **exact** (`lower(trim(...))`, pas de fuzzy/fishing)
- Refuse les requêtes `< 3 caractères` (anti-fishing)
- SECURITY DEFINER + service_role only

### Edge Function `loi25-process`
- Nouveau endpoint `POST /lookup` avec body `{ name }`
- Auth admin vérifiée comme les autres endpoints

### UI modulimo-admin
- Helper `_loi25Call` adapté pour accepter soit une string `client_id`, soit un objet body custom `{ name }`
- Hook dans `saveClient` : avant l'INSERT d'un nouveau client, appelle `/lookup`. Si match → `confirm()` avec détails (nom, immeuble, date, admin signataire). L'admin peut quand même procéder si c'est un nouveau compte légitime
- Skip pour les UPDATE (id présent)

## Workflow attendu
1. Admin clique "+ Nouveau client", remplit "Lucy B"
2. Click "Enregistrer"
3. Système vérifie → match trouvé : "Lucy B anonymisée le 26/04/2026 par simon@..."
4. Confirm dialog : "Créer quand même un nouveau compte ?"
5. Admin valide en connaissance de cause

## Déploiement
1. Merger
2. Run `sql/021` dans SQL Editor central
3. `supabase functions deploy loi25-process --project-ref bpxscgrbxjscicpnheep`
4. Hard refresh modulimo-admin

## Test
- [ ] Créer "Lucy B" (nom déjà anonymisé) → confirm popup
- [ ] Créer un nom unique → pas de popup
- [ ] Edit un client existant → pas de check (skip pour UPDATE)
- [ ] Nom < 3 caractères → pas de match retourné

https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q)_