### PR TITLE
Phase 1 refonte UX : page detail client (vue 360 avec 5 tabs)

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,10 +77,24 @@
   .modal-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,.7); z-index: 999; align-items: center; justify-content: center; padding: 20px; }
   .modal-overlay.open { display: flex; }
   .modal { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); width: 100%; max-width: 520px; max-height: 90vh; display: flex; flex-direction: column; }
+  .modal.modal-wide { max-width: 1100px; }
   .modal-header { padding: 18px 20px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; flex-shrink: 0; }
   .modal-title { font-weight: 600; font-size: 15px; }
   .modal-body { padding: 20px; overflow-y: auto; flex: 1; }
   .modal-footer { padding: 14px 20px; border-top: 1px solid var(--border); display: flex; justify-content: flex-end; gap: 10px; flex-shrink: 0; }
+  /* Tabs internes pour modal detail client */
+  .detail-tabs { display: flex; gap: 0; border-bottom: 1px solid var(--border); margin: -20px -20px 20px; padding: 0 20px; flex-shrink: 0; overflow-x: auto; }
+  .detail-tab { background: none; border: none; color: var(--text2); padding: 12px 16px; cursor: pointer; font-size: 13px; font-weight: 500; border-bottom: 2px solid transparent; white-space: nowrap; transition: all .15s; }
+  .detail-tab:hover { color: var(--text); }
+  .detail-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+  .detail-pane { display: none; }
+  .detail-pane.active { display: block; }
+  .detail-section h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .08em; color: var(--text3); margin: 16px 0 8px; }
+  .kv-grid { display: grid; grid-template-columns: 180px 1fr; gap: 6px 14px; font-size: 13px; }
+  .kv-grid dt { color: var(--text3); }
+  .kv-grid dd { color: var(--text); margin: 0; }
+  .timeline-item { border-left: 2px solid var(--border); padding: 10px 14px; margin-bottom: 8px; font-size: 13px; }
+  .timeline-item.active { border-left-color: var(--accent); background: rgba(200,169,110,.05); }
   .toast { position: fixed; bottom: 20px; right: 20px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 10px 16px; font-size: 13px; z-index: 9999; transform: translateY(100px); opacity: 0; transition: all .3s; }
   .toast.show { transform: translateY(0); opacity: 1; }
   .divider { border: none; border-top: 1px solid var(--border); margin: 20px 0; }
@@ -611,6 +625,54 @@
   </div>
 </div>
 
+<!-- Modal Detail Client (vue 360 — Phase 1 refonte UX) -->
+<div class="modal-overlay" id="modal-client-detail">
+  <div class="modal modal-wide">
+    <div class="modal-header">
+      <span class="modal-title" id="cd-title">Detail client</span>
+      <div style="display:flex;gap:8px;">
+        <button class="btn btn-secondary btn-sm" id="cd-edit-btn" onclick="cdEditCurrent()">✎ Modifier</button>
+        <button onclick="closeModal('modal-client-detail')" style="background:none;border:none;color:var(--text2);font-size:18px;cursor:pointer">✕</button>
+      </div>
+    </div>
+    <div class="modal-body">
+      <!-- Tabs nav -->
+      <div class="detail-tabs">
+        <button class="detail-tab active" data-tab="profil"   onclick="cdShowTab('profil')">👤 Profil</button>
+        <button class="detail-tab"        data-tab="contracts" onclick="cdShowTab('contracts')">📄 Contrats</button>
+        <button class="detail-tab"        data-tab="invoices"  onclick="cdShowTab('invoices')">🧾 Factures</button>
+        <button class="detail-tab"        data-tab="balance"   onclick="cdShowTab('balance')">💰 Solde</button>
+        <button class="detail-tab"        data-tab="activity"  onclick="cdShowTab('activity')">📊 Activite</button>
+      </div>
+
+      <!-- Pane Profil -->
+      <div class="detail-pane active" id="cd-pane-profil">
+        <div id="cd-profil-content"></div>
+      </div>
+
+      <!-- Pane Contrats -->
+      <div class="detail-pane" id="cd-pane-contracts">
+        <div id="cd-contracts-content"></div>
+      </div>
+
+      <!-- Pane Factures -->
+      <div class="detail-pane" id="cd-pane-invoices">
+        <div id="cd-invoices-content"></div>
+      </div>
+
+      <!-- Pane Solde -->
+      <div class="detail-pane" id="cd-pane-balance">
+        <div id="cd-balance-content"></div>
+      </div>
+
+      <!-- Pane Activite -->
+      <div class="detail-pane" id="cd-pane-activity">
+        <div id="cd-activity-content"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Modal Licence -->
 <div class="modal-overlay" id="modal-licence">
   <div class="modal">
@@ -959,15 +1021,16 @@ async function loadClients() {
   const owners = clientsCache.filter(c => c.client_type === 'owner');
   const tenants = clientsCache.filter(c => c.client_type !== 'owner');
 
-  // Boutons d'actions par row : "Voir" si anonymise (lecture seule),
-  // sinon Modifier + Activer/Desactiver. On ne propose plus de re-activer
-  // un client anonymise — ce serait incoherent (impossible de savoir
-  // qui c'est, et le verrou DB refuserait toute modification).
+  // Boutons d'actions par row :
+  //  - "Detail" = nouvelle vue 360 avec tabs (Phase 1 refonte UX)
+  //  - "Activer/Desactiver" reste accessible pour quick toggle
+  //  - Pas de bouton sur les anonymises (clic sur n'importe ou ouvre Detail
+  //    en lecture seule via openClientDetail).
   function _actionsForClient(c, opts) {
     if (c.anonymized_at) {
-      return '<button class="btn btn-secondary btn-sm" onclick="editClientById(\'' + c.id + '\')">👁 Voir</button>';
+      return '<button class="btn btn-secondary btn-sm" onclick="openClientDetail(\'' + c.id + '\')">👁 Voir</button>';
     }
-    let html = '<button class="btn btn-secondary btn-sm" onclick="editClientById(\'' + c.id + '\')">Modifier</button>';
+    let html = '<button class="btn btn-secondary btn-sm" onclick="openClientDetail(\'' + c.id + '\')">📋 Detail</button>';
     if (opts && opts.contract) {
       html += '<button class="btn btn-info btn-sm" onclick="openContractForClient(\'' + c.id + '\', \'owner\')">📄 Contrat</button>';
     }
@@ -3176,6 +3239,278 @@ async function loi25ShowCertificate() {
   } catch (e) {
     toast('Echec : ' + (e.message || e), 'error');
   }
+}
+
+// ============================================================================
+// PAGE DETAIL CLIENT (Phase 1 refonte UX) — vue 360 avec tabs internes
+// ============================================================================
+let _cdCurrentClient = null;
+
+function _cdFmtMoney(n) { return (n == null) ? '—' : Number(n).toFixed(2) + ' $'; }
+function _cdFmtDate(s)  { if (!s) return '—'; try { return new Date(s).toLocaleDateString('fr-CA'); } catch(_) { return s; } }
+function _cdFmtDateTime(s) { if (!s) return '—'; try { return new Date(s).toLocaleString('fr-CA'); } catch(_) { return s; } }
+function _cdEsc(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+}
+
+async function openClientDetail(clientId) {
+  const c = clientsCache.find(x => x.id === clientId);
+  if (!c) { toast('Client introuvable', 'error'); return; }
+  _cdCurrentClient = c;
+
+  // Header titre + statut
+  const isAnon = !!c.anonymized_at;
+  let headerName = c.name;
+  if (isAnon) {
+    // Cherche le certificat dans le map deja chargee par loadClients
+    // (le map est local a loadClients, on refait juste un fetch ciblé).
+    const { data: certs } = await sb.from('anonymization_certificates')
+      .select('subject_name, subject_unit, building_name')
+      .eq('client_id', clientId).limit(1);
+    const ct = (certs || [])[0];
+    if (ct) {
+      const loc = [ct.building_name, ct.subject_unit].filter(Boolean).join(' · ');
+      headerName = ct.subject_name + (loc ? ' — ' + loc : '');
+    }
+  }
+  document.getElementById('cd-title').textContent = (isAnon ? '🔒 ' : '') + headerName;
+  document.getElementById('cd-edit-btn').style.display = isAnon ? 'none' : '';
+
+  // Reset tabs et affiche profil
+  cdShowTab('profil');
+
+  // Render synchrone du profil (donnees deja en cache)
+  cdRenderProfil(c);
+
+  // Lance fetch en parallele pour les autres tabs (lazy mais on
+  // declenche tout de suite pour que ce soit pret au switch).
+  Promise.all([
+    cdLoadContracts(clientId),
+    cdLoadInvoices(clientId),
+    cdLoadBalance(clientId),
+    cdLoadActivity(clientId)
+  ]).catch(e => console.warn('[client-detail] fetch error', e));
+
+  openModal('modal-client-detail');
+}
+
+function cdShowTab(name) {
+  document.querySelectorAll('#modal-client-detail .detail-tab').forEach(b => {
+    b.classList.toggle('active', b.dataset.tab === name);
+  });
+  document.querySelectorAll('#modal-client-detail .detail-pane').forEach(p => {
+    p.classList.toggle('active', p.id === 'cd-pane-' + name);
+  });
+}
+
+function cdEditCurrent() {
+  if (!_cdCurrentClient) return;
+  closeModal('modal-client-detail');
+  // Reutilise le modal-client existant pour l'edition
+  editClient(_cdCurrentClient);
+}
+
+// ── Tab Profil ───────────────────────────────────────────────────────────
+function cdRenderProfil(c) {
+  const mods = c.cohabitat_modules || {};
+  const modList = [
+    mods.spaces ? '🏠 Espaces' : null,
+    mods.trips  ? '🚗 Auto-partage' : null,
+    mods.lunch  ? '🍱 Lunch' : null
+  ].filter(Boolean).join(' · ') || '—';
+  const typeLabels = { owner: '🏢 Propriétaire', local: '🏠 Locataire local', network: '🔗 Locataire réseau' };
+  const status = c.anonymized_at
+    ? '<span class="badge badge-gray">🔒 Archivé le ' + _cdFmtDate(c.anonymized_at) + '</span>'
+    : '<span class="badge ' + (c.is_active ? 'badge-green' : 'badge-red') + '">' + (c.is_active ? 'Actif' : 'Inactif') + '</span>';
+
+  let html = '<div class="detail-section"><h3>Identité</h3><dl class="kv-grid">';
+  html += '<dt>Nom</dt><dd><strong>' + _cdEsc(c.name) + '</strong></dd>';
+  html += '<dt>Type</dt><dd>' + (typeLabels[c.client_type] || c.client_type) + '</dd>';
+  html += '<dt>Statut</dt><dd>' + status + '</dd>';
+  html += '<dt>Courriel contact</dt><dd>' + (c.contact_email ? '<a href="mailto:' + _cdEsc(c.contact_email) + '">' + _cdEsc(c.contact_email) + '</a>' : '—') + '</dd>';
+  html += '<dt>Nom contact</dt><dd>' + _cdEsc(c.contact_name || '—') + '</dd>';
+  html += '<dt>Adresse</dt><dd>' + _cdEsc([c.address, c.city, c.province].filter(Boolean).join(', ') || '—') + '</dd>';
+  html += '<dt>Modules</dt><dd>' + modList + '</dd>';
+  html += '<dt>Inscrit le</dt><dd>' + _cdFmtDate(c.created_at) + '</dd>';
+  if (c.cohabitat_user_id) html += '<dt>User CoHabitat</dt><dd><code style="font-size:11px;">' + _cdEsc(c.cohabitat_user_id) + '</code></dd>';
+  html += '</dl></div>';
+
+  // Section Loi 25 (boutons reutilises)
+  if (!c.anonymized_at) {
+    html += '<div class="detail-section"><h3>Loi 25</h3>';
+    html += '<div style="display:flex;gap:8px;flex-wrap:wrap;">';
+    html += '<button class="btn btn-secondary btn-sm" onclick="cdLoi25(\'html\')">📄 Rapport HTML</button>';
+    html += '<button class="btn btn-secondary btn-sm" onclick="cdLoi25(\'json\')">📥 Export JSON</button>';
+    html += '<button class="btn btn-danger btn-sm" onclick="cdLoi25(\'anon\')">🔒 Anonymiser</button>';
+    html += '</div></div>';
+  } else {
+    html += '<div class="detail-section"><h3>Certificat d\'anonymisation</h3>';
+    html += '<button class="btn btn-secondary btn-sm" onclick="cdLoi25(\'cert\')">📋 Re-télécharger certificat</button>';
+    html += '</div>';
+  }
+
+  document.getElementById('cd-profil-content').innerHTML = html;
+}
+
+async function cdLoi25(action) {
+  const id = _cdCurrentClient && _cdCurrentClient.id;
+  if (!id) return;
+  // Re-utilise les helpers existants en simulant le state du modal-client.
+  const hidden = document.getElementById('client-id');
+  const oldVal = hidden.value;
+  hidden.value = id;
+  try {
+    if (action === 'html')      await loi25ExportHTML();
+    else if (action === 'json') await loi25Export();
+    else if (action === 'anon') { await loi25Anonymize(); closeModal('modal-client-detail'); await loadClients(); }
+    else if (action === 'cert') await loi25ShowCertificate();
+  } finally {
+    hidden.value = oldVal;
+  }
+}
+
+// ── Tab Contrats ─────────────────────────────────────────────────────────
+async function cdLoadContracts(clientId) {
+  const el = document.getElementById('cd-contracts-content');
+  el.innerHTML = '<div style="color:var(--text3);font-size:13px;padding:8px 0;">Chargement…</div>';
+  const { data, error } = await sb.from('contracts')
+    .select('id, type, plan, status, starts_at, ends_at, paid_until, monthly_amount, billing_mode, signed_at, signed_by_name, created_at')
+    .or('client_id.eq.' + clientId + ',owner_client_id.eq.' + clientId)
+    .order('created_at', { ascending: false });
+  if (error) { el.innerHTML = '<div style="color:var(--accent3);">Erreur : ' + _cdEsc(error.message) + '</div>'; return; }
+  if (!data || !data.length) { el.innerHTML = '<div style="color:var(--text3);font-style:italic;">Aucun contrat.</div>'; return; }
+  const active   = data.filter(c => c.status === 'active');
+  const inactive = data.filter(c => c.status !== 'active');
+  function ctRow(c) {
+    return '<div class="timeline-item ' + (c.status === 'active' ? 'active' : '') + '">'
+      + '<strong>' + _cdEsc(c.plan || '—') + '</strong> · ' + _cdEsc(c.type) + ' · '
+      + '<span class="badge badge-gray" style="font-size:10px;">' + _cdEsc(c.status) + '</span><br>'
+      + '<span style="font-size:11px;color:var(--text3);">'
+      + _cdFmtDate(c.starts_at) + ' → ' + _cdFmtDate(c.ends_at || '∞')
+      + (c.monthly_amount != null ? ' · ' + _cdFmtMoney(c.monthly_amount) + '/mois' : '')
+      + (c.signed_at ? ' · ✓ signé ' + _cdFmtDate(c.signed_at) : ' · non signé')
+      + '</span></div>';
+  }
+  let html = '';
+  if (active.length)   html += '<div class="detail-section"><h3>Actifs (' + active.length + ')</h3>' + active.map(ctRow).join('') + '</div>';
+  if (inactive.length) html += '<div class="detail-section"><h3>Historique (' + inactive.length + ')</h3>' + inactive.map(ctRow).join('') + '</div>';
+  el.innerHTML = html;
+}
+
+// ── Tab Factures ─────────────────────────────────────────────────────────
+async function cdLoadInvoices(clientId) {
+  const el = document.getElementById('cd-invoices-content');
+  el.innerHTML = '<div style="color:var(--text3);font-size:13px;padding:8px 0;">Chargement…</div>';
+  const { data, error } = await sb.from('invoices')
+    .select('id, period_start, period_end, issued_at, total_amount, status, billing_mode, paid_at')
+    .or('client_id.eq.' + clientId + ',owner_client_id.eq.' + clientId)
+    .order('issued_at', { ascending: false });
+  if (error) { el.innerHTML = '<div style="color:var(--accent3);">Erreur : ' + _cdEsc(error.message) + '</div>'; return; }
+  if (!data || !data.length) { el.innerHTML = '<div style="color:var(--text3);font-style:italic;">Aucune facture.</div>'; return; }
+  let totalIssued = 0, totalPaid = 0, totalOverdue = 0;
+  data.forEach(i => {
+    const amt = Number(i.total_amount || 0);
+    totalIssued += amt;
+    if (i.status === 'paid') totalPaid += amt;
+    if (i.status === 'overdue') totalOverdue += amt;
+  });
+  const statusLabels = { issued: 'À encaisser', paid: 'Payée', overdue: 'En retard', cancelled: 'Annulée' };
+  const statusColors = { issued: 'badge-yellow', paid: 'badge-green', overdue: 'badge-red', cancelled: 'badge-gray' };
+  let html = '<div class="detail-section"><h3>Résumé</h3><dl class="kv-grid">';
+  html += '<dt>Total émis</dt><dd>' + _cdFmtMoney(totalIssued) + ' (' + data.length + ' factures)</dd>';
+  html += '<dt>Payé</dt><dd style="color:#5a8;">' + _cdFmtMoney(totalPaid) + '</dd>';
+  if (totalOverdue > 0) html += '<dt>En retard</dt><dd style="color:var(--accent3);">' + _cdFmtMoney(totalOverdue) + '</dd>';
+  html += '</dl></div>';
+  html += '<div class="detail-section"><h3>Détail</h3><table style="font-size:12px;">';
+  html += '<thead><tr><th>Période</th><th>Émise</th><th style="text-align:right">Total</th><th>Statut</th></tr></thead><tbody>';
+  data.forEach(i => {
+    html += '<tr><td>' + _cdEsc(i.period_start) + ' → ' + _cdEsc(i.period_end) + '</td>'
+         + '<td>' + _cdFmtDate(i.issued_at) + '</td>'
+         + '<td style="text-align:right">' + _cdFmtMoney(i.total_amount) + '</td>'
+         + '<td><span class="badge ' + (statusColors[i.status] || 'badge-gray') + '">' + (statusLabels[i.status] || i.status) + '</span></td></tr>';
+  });
+  html += '</tbody></table></div>';
+  el.innerHTML = html;
+}
+
+// ── Tab Solde ────────────────────────────────────────────────────────────
+async function cdLoadBalance(clientId) {
+  const el = document.getElementById('cd-balance-content');
+  el.innerHTML = '<div style="color:var(--text3);font-size:13px;padding:8px 0;">Chargement…</div>';
+  const [balRes, depRes, txRes] = await Promise.all([
+    sb.from('balances').select('virtual_balance, updated_at, building_id').eq('client_id', clientId).maybeSingle(),
+    sb.from('dependent_balances').select('external_dep_id, virtual_balance, updated_at').eq('client_id', clientId),
+    sb.from('transactions').select('amount, balance_after, type, description, created_at').eq('client_id', clientId).order('created_at', { ascending: false }).limit(50)
+  ]);
+  let html = '<div class="detail-section"><h3>Solde courant</h3><dl class="kv-grid">';
+  if (balRes.data) {
+    html += '<dt>Solde principal</dt><dd><strong>' + _cdFmtMoney(balRes.data.virtual_balance) + '</strong></dd>';
+    html += '<dt>Dernière mise à jour</dt><dd>' + _cdFmtDateTime(balRes.data.updated_at) + '</dd>';
+  } else {
+    html += '<dt>Solde</dt><dd style="color:var(--text3);font-style:italic;">Aucun solde central</dd>';
+  }
+  html += '</dl></div>';
+  if (depRes.data && depRes.data.length) {
+    html += '<div class="detail-section"><h3>Dépendants (' + depRes.data.length + ')</h3>';
+    html += '<table style="font-size:12px;"><thead><tr><th>External ID</th><th style="text-align:right">Solde</th><th>Maj</th></tr></thead><tbody>';
+    depRes.data.forEach(d => {
+      html += '<tr><td><code style="font-size:11px;">' + _cdEsc(d.external_dep_id) + '</code></td>'
+           + '<td style="text-align:right">' + _cdFmtMoney(d.virtual_balance) + '</td>'
+           + '<td>' + _cdFmtDate(d.updated_at) + '</td></tr>';
+    });
+    html += '</tbody></table></div>';
+  }
+  html += '<div class="detail-section"><h3>Mouvements (' + (txRes.data ? txRes.data.length : 0) + ' derniers)</h3>';
+  if (!txRes.data || !txRes.data.length) html += '<div style="color:var(--text3);font-style:italic;">Aucun mouvement.</div>';
+  else {
+    html += '<table style="font-size:12px;"><thead><tr><th>Date</th><th>Type</th><th>Description</th><th style="text-align:right">Montant</th><th style="text-align:right">Solde après</th></tr></thead><tbody>';
+    txRes.data.forEach(t => {
+      const amt = Number(t.amount || 0);
+      const color = amt < 0 ? 'color:#a44;' : 'color:#2a7;';
+      html += '<tr><td>' + _cdFmtDateTime(t.created_at) + '</td>'
+           + '<td>' + _cdEsc(t.type) + '</td>'
+           + '<td>' + _cdEsc(t.description || '—') + '</td>'
+           + '<td style="text-align:right;' + color + '">' + (amt >= 0 ? '+' : '') + _cdFmtMoney(amt) + '</td>'
+           + '<td style="text-align:right">' + _cdFmtMoney(t.balance_after) + '</td></tr>';
+    });
+    html += '</tbody></table>';
+  }
+  html += '</div>';
+  el.innerHTML = html;
+}
+
+// ── Tab Activité ─────────────────────────────────────────────────────────
+async function cdLoadActivity(clientId) {
+  const el = document.getElementById('cd-activity-content');
+  el.innerHTML = '<div style="color:var(--text3);font-size:13px;padding:8px 0;">Chargement…</div>';
+  // Cote central, on a les lunch_transactions. Espaces et trajets vivent
+  // dans CoHabitat (cross-DB), pas accessibles ici.
+  const { data, error } = await sb.from('lunch_transactions')
+    .select('amount, machine_id, buyer_name, created_at, idempotency_key')
+    .eq('client_id', clientId).order('created_at', { ascending: false }).limit(50);
+  let html = '<div class="detail-section"><h3>🍱 Achats Machine Lunch</h3>';
+  if (error) {
+    html += '<div style="color:var(--accent3);">Erreur : ' + _cdEsc(error.message) + '</div>';
+  } else if (!data || !data.length) {
+    html += '<div style="color:var(--text3);font-style:italic;">Aucun achat lunch.</div>';
+  } else {
+    let total = 0;
+    data.forEach(d => total += Number(d.amount || 0));
+    html += '<div style="font-size:11px;color:var(--text3);margin-bottom:8px;">Total : <strong>' + _cdFmtMoney(total) + '</strong> sur ' + data.length + ' achats</div>';
+    html += '<table style="font-size:12px;"><thead><tr><th>Date</th><th>Machine</th><th>Acheteur</th><th style="text-align:right">Montant</th></tr></thead><tbody>';
+    data.forEach(d => {
+      html += '<tr><td>' + _cdFmtDateTime(d.created_at) + '</td>'
+           + '<td>' + _cdEsc(d.machine_id || '—') + '</td>'
+           + '<td>' + _cdEsc(d.buyer_name || '—') + '</td>'
+           + '<td style="text-align:right">' + _cdFmtMoney(d.amount) + '</td></tr>';
+    });
+    html += '</tbody></table>';
+  }
+  html += '</div>';
+  html += '<div class="detail-section"><h3>🏠 Espaces · 🚗 Trajets</h3>';
+  html += '<div style="color:var(--text3);font-size:12px;font-style:italic;">Ces données vivent côté CoHabitat de l\'immeuble (pas accessibles depuis modulimo central). Demander à l\'admin local pour le détail.</div>';
+  html += '</div>';
+  el.innerHTML = html;
 }
 
 async function saveClient() {


### PR DESCRIPTION
## Phase 1 refonte UX — Page détail client (vue 360°)

Click "📋 Détail" sur une row de la liste Clients ouvre une **vue 360°** dans un modal large (1100px) avec **5 tabs internes** :

| Tab | Contenu |
|---|---|
| 👤 **Profil** | Identité, type, statut, modules, dates, boutons Loi 25 |
| 📄 **Contrats** | Timeline (actifs en haut, historique en bas) avec plan, dates, montant, signature |
| 🧾 **Factures** | Résumé totaux (émis/payé/retard) + tableau détail avec statuts colorés |
| 💰 **Solde** | Solde central courant + dépendants + 50 derniers mouvements |
| 📊 **Activité** | Achats lunch (central) ; espaces/trajets côté CoHabitat (mention) |

## Implémentation
- Nouveau modal `modal-client-detail` avec classe `.modal-wide` (1100px)
- CSS additionnel : `.detail-tabs`, `.detail-pane`, `.kv-grid`, `.timeline-item`
- `openClientDetail(id)` charge le profil de manière synchrone (déjà en cache) puis lance les 4 autres en parallèle
- `cdLoi25(action)` réutilise les helpers Loi 25 existants en injectant `client-id` dans le hidden field — zéro duplication
- Bouton "✎ Modifier" dans le header → ouvre le modal-client legacy pour édition des champs

## Comportement sur les anonymisés
- Bouton "📋 Détail" devient "👁 Voir"
- Header : "🔒 [Nom original]" (depuis le certificat)
- "✎ Modifier" caché
- Section Loi 25 simplifiée : seul "📋 Re-télécharger certificat"

## Flow
1. Liste Clients → "📋 Détail" → modal s'ouvre sur tab Profil
2. Tabs : profile (instant), autres lazy mais pré-chargés en parallèle
3. Pour modifier : "✎ Modifier" → modal-client legacy → "Enregistrer" → revient à la liste
4. Pour Loi 25 : boutons inline dans le tab Profil

## Test
- [ ] Liste Clients → "📋 Détail" sur Lucy B → modal s'ouvre
- [ ] Tab Contrats → voir la timeline (actifs/historique)
- [ ] Tab Factures → résumé totaux + tableau
- [ ] Tab Solde → balance + transactions
- [ ] Tab Activité → lunch_transactions (si présentes)
- [ ] "✎ Modifier" → ouvre le formulaire d'édition legacy
- [ ] Boutons Loi 25 dans tab Profil → comme avant
- [ ] Sur Emy (anonymisée) → vue lecture seule, header "🔒 Emy Beauchemin — Pointe-Est"

## Prochaines phases
- #2 — Réorg nav (regrouper Config, supprimer Soldes/Contrats)
- #3 — Filtres + colonnes liste Clients
- #4 — Page Facturation enrichie

https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rojk6fDYLmN5pJfA8msJ2q)_