### PR TITLE
Demandes : stats réseau (central) + RPC scopées par building (CoHabitat)

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,7 @@
     <div class="sidebar">
       <div class="nav-item active" onclick="nav('dashboard')">📊 Tableau de bord</div>
       <div class="nav-item" onclick="nav('clients')">🏢 Clients</div>
+      <div class="nav-item" onclick="nav('demandes')">📊 Demandes (stats)</div>
       <div class="nav-item" onclick="nav('balances')">💳 Soldes</div>
       <div class="nav-item" onclick="nav('contracts')">📄 Contrats</div>
       <div class="nav-item" onclick="nav('invoices')">🧾 Factures</div>
@@ -184,6 +185,44 @@
           <table>
             <thead><tr><th>Nom</th><th>Type</th><th>Actif</th><th>Contact</th><th>Modules</th><th>Actions</th></tr></thead>
             <tbody id="clients-tbody"></tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- DEMANDES (stats agregees seulement) -->
+      <!-- Modulimo central n'autorise pas les locataires individuels par
+           immeuble (c'est l'admin CoHabitat de chaque immeuble qui le fait).
+           Cet onglet n'expose donc que les statistiques agregees pour
+           le suivi du reseau global. -->
+      <div id="page-demandes" class="page">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;">
+          <div class="page-title" style="margin:0">Demandes — statistiques réseau</div>
+          <button class="btn btn-secondary btn-sm" onclick="loadDemandesStats()">↻ Rafraîchir</button>
+        </div>
+        <div style="background:rgba(200,169,110,.08);border:1px solid rgba(200,169,110,.25);border-radius:8px;padding:12px 16px;margin-bottom:20px;font-size:13px;color:var(--text2);">
+          <span style="color:var(--accent);font-weight:600;">📌 Politique :</span> L'approbation des candidatures de location se fait dans <strong>l'onglet Demandes du CoHabitat de chaque immeuble</strong>. Modulimo central ne décide pas pour le compte d'un propriétaire — cette page agrège uniquement les statistiques.
+        </div>
+        <div class="stats-grid" id="demandes-kpis" style="margin-bottom:20px;"></div>
+        <div class="card" style="padding:0;margin-bottom:20px;">
+          <div class="card-title" style="padding:14px 16px 0;">Par immeuble</div>
+          <table>
+            <thead><tr>
+              <th>Immeuble</th>
+              <th style="text-align:right">Reçues</th>
+              <th style="text-align:right">En éval.</th>
+              <th style="text-align:right">Acceptées</th>
+              <th style="text-align:right">Refusées</th>
+              <th style="text-align:right">Score moyen</th>
+              <th style="text-align:right">Loyer cible moyen</th>
+            </tr></thead>
+            <tbody id="demandes-by-building"></tbody>
+          </table>
+        </div>
+        <div class="card" style="padding:0;">
+          <div class="card-title" style="padding:14px 16px 0;">Par mois (12 derniers)</div>
+          <table>
+            <thead><tr><th>Mois</th><th style="text-align:right">Reçues</th><th style="text-align:right">Acceptées</th><th style="text-align:right">Refusées</th></tr></thead>
+            <tbody id="demandes-by-month"></tbody>
           </table>
         </div>
       </div>
@@ -951,6 +990,7 @@ function nav(page) {
   event.target.classList.add('active');
   if (page === 'dashboard') loadDashboard();
   if (page === 'clients')   loadClients();
+  if (page === 'demandes')  loadDemandesStats();
   if (page === 'balances')  loadBalances();
   if (page === 'contracts') loadContracts();
   if (page === 'invoices')  loadInvoices();
@@ -4008,6 +4048,104 @@ async function saveNetwork() {
   toast('Réseau créé', 'success');
   closeModal('modal-network');
   loadNetworks();
+}
+
+// ═══════════════════════════════════════════════════════════
+//  DEMANDES — stats agregees uniquement (lecture seule)
+// ═══════════════════════════════════════════════════════════
+// L'approbation des candidatures est deleguee a l'admin CoHabitat
+// de chaque immeuble. Modulimo central ne fait que l'observation
+// agregee : volume, taux d'acceptation, score moyen, par immeuble
+// et par mois. Source : vue public.candidatures_analytics.
+async function loadDemandesStats() {
+  const kpiEl = document.getElementById('demandes-kpis');
+  const buildingEl = document.getElementById('demandes-by-building');
+  const monthEl = document.getElementById('demandes-by-month');
+  kpiEl.innerHTML = '';
+  buildingEl.innerHTML = '<tr><td colspan="7" style="text-align:center;color:var(--text3)">Chargement…</td></tr>';
+  monthEl.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--text3)">Chargement…</td></tr>';
+
+  const [statsRes, buildRes] = await Promise.all([
+    sb.from('candidatures_analytics').select('*'),
+    sb.from('building_registry').select('id,name')
+  ]);
+  if (statsRes.error) { toast('Erreur stats: ' + statsRes.error.message, 'error'); return; }
+  const rows = statsRes.data || [];
+  const buildings = new Map((buildRes.data || []).map(b => [b.id, b.name]));
+
+  // KPIs globaux
+  let total = 0, accepted = 0, refused = 0, pending = 0;
+  rows.forEach(r => {
+    total += Number(r.total) || 0;
+    if (r.status === 'accepte') accepted += Number(r.total) || 0;
+    else if (r.status === 'refuse') refused += Number(r.total) || 0;
+    else if (r.status === 'recu' || r.status === 'en_evaluation') pending += Number(r.total) || 0;
+  });
+  const acceptRate = (accepted + refused) > 0 ? (100 * accepted / (accepted + refused)).toFixed(0) + ' %' : '—';
+  kpiEl.innerHTML = [
+    { num: total,       lbl: 'Candidatures (12 mois max)' },
+    { num: pending,     lbl: 'À traiter' },
+    { num: accepted,    lbl: 'Acceptées' },
+    { num: acceptRate,  lbl: 'Taux d\'acceptation' }
+  ].map(s => `<div class="stat-card"><div class="stat-num">${s.num}</div><div class="stat-lbl">${s.lbl}</div></div>`).join('');
+
+  // Aggregation par immeuble
+  const byB = new Map();
+  rows.forEach(r => {
+    const k = r.building_id || '__none__';
+    if (!byB.has(k)) byB.set(k, { recu:0, en_evaluation:0, accepte:0, refuse:0, scoreSum:0, scoreN:0, rentSum:0, rentN:0 });
+    const acc = byB.get(k);
+    const n = Number(r.total) || 0;
+    if (r.status === 'recu')          acc.recu += n;
+    if (r.status === 'en_evaluation') acc.en_evaluation += n;
+    if (r.status === 'accepte')       acc.accepte += n;
+    if (r.status === 'refuse')        acc.refuse += n;
+    if (r.avg_score != null)       { acc.scoreSum += Number(r.avg_score) * n; acc.scoreN += n; }
+    if (r.avg_target_rent != null) { acc.rentSum  += Number(r.avg_target_rent) * n; acc.rentN += n; }
+  });
+  const buildingRows = [...byB.entries()].map(([id, a]) => ({
+    name: id === '__none__' ? '— (aucun immeuble)' : (buildings.get(id) || id.slice(0,8) + '…'),
+    ...a,
+    avgScore: a.scoreN ? (a.scoreSum / a.scoreN).toFixed(1) : '—',
+    avgRent:  a.rentN  ? (a.rentSum  / a.rentN ).toFixed(0) + ' $' : '—'
+  })).sort((x, y) => (y.recu + y.en_evaluation + y.accepte + y.refuse) - (x.recu + x.en_evaluation + x.accepte + x.refuse));
+  buildingEl.innerHTML = buildingRows.length ? buildingRows.map(r => `
+    <tr>
+      <td>${escapeHtmlStats(r.name)}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums;">${r.recu}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums;">${r.en_evaluation}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums;">${r.accepte}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums;">${r.refuse}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums;">${r.avgScore}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums;">${r.avgRent}</td>
+    </tr>`).join('') : '<tr><td colspan="7" style="text-align:center;color:var(--text3);padding:18px;">Aucune candidature</td></tr>';
+
+  // Aggregation par mois
+  const byM = new Map();
+  rows.forEach(r => {
+    const k = (r.month || '').slice(0, 7);
+    if (!k) return;
+    if (!byM.has(k)) byM.set(k, { total:0, accepte:0, refuse:0 });
+    const acc = byM.get(k);
+    const n = Number(r.total) || 0;
+    acc.total += n;
+    if (r.status === 'accepte') acc.accepte += n;
+    if (r.status === 'refuse')  acc.refuse  += n;
+  });
+  const monthRows = [...byM.entries()].sort((a, b) => b[0].localeCompare(a[0])).slice(0, 12);
+  monthEl.innerHTML = monthRows.length ? monthRows.map(([m, a]) => `
+    <tr>
+      <td>${m}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums;">${a.total}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums;">${a.accepte}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums;">${a.refuse}</td>
+    </tr>`).join('') : '<tr><td colspan="4" style="text-align:center;color:var(--text3);padding:18px;">—</td></tr>';
+}
+
+function escapeHtmlStats(s) {
+  return String(s ?? '').replace(/[&<>"']/g, ch => ({
+    '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;'
+  }[ch]));
 }
 
 // HELPERS

--- a/index.html
+++ b/index.html
@@ -138,7 +138,6 @@
     <div class="sidebar">
       <div class="nav-item active" onclick="nav('dashboard')">📊 Tableau de bord</div>
       <div class="nav-item" onclick="nav('clients')">🏢 Clients</div>
-      <div class="nav-item" onclick="nav('demandes')">📋 Demandes</div>
       <div class="nav-item" onclick="nav('balances')">💳 Soldes</div>
       <div class="nav-item" onclick="nav('contracts')">📄 Contrats</div>
       <div class="nav-item" onclick="nav('invoices')">🧾 Factures</div>
@@ -187,50 +186,6 @@
             <tbody id="clients-tbody"></tbody>
           </table>
         </div>
-      </div>
-
-      <!-- DEMANDES (Candidatures locataires) -->
-      <div id="page-demandes" class="page">
-        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;gap:10px;flex-wrap:wrap;">
-          <div class="page-title" style="margin:0">Demandes de location</div>
-          <div style="display:flex;gap:10px;align-items:center;">
-            <select id="demandes-building-filter" onchange="renderDemandes()" style="padding:8px 12px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;font-size:13px;">
-              <option value="">Tous les immeubles</option>
-            </select>
-            <select id="demandes-status-filter" onchange="renderDemandes()" style="padding:8px 12px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;font-size:13px;">
-              <option value="ouvertes" selected>À traiter</option>
-              <option value="">Toutes</option>
-              <option value="recu">Reçues</option>
-              <option value="en_evaluation">En évaluation</option>
-              <option value="accepte">Acceptées</option>
-              <option value="refuse">Refusées</option>
-              <option value="retire">Retirées</option>
-              <option value="expire">Expirées</option>
-            </select>
-            <button class="btn btn-secondary btn-sm" onclick="loadDemandes()">↻ Rafraîchir</button>
-          </div>
-        </div>
-        <div class="card" style="padding:0">
-          <table>
-            <thead>
-              <tr>
-                <th>Candidat</th>
-                <th>Courriel</th>
-                <th>Immeuble</th>
-                <th style="text-align:right">Loyer cible</th>
-                <th style="text-align:right">Revenu annuel</th>
-                <th>Score</th>
-                <th>Statut</th>
-                <th>Reçue le</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody id="demandes-tbody">
-              <tr><td colspan="9" style="text-align:center;color:var(--text3)">Chargement…</td></tr>
-            </tbody>
-          </table>
-        </div>
-        <div id="demandes-summary" style="margin-top:16px;font-size:13px;color:var(--text2);"></div>
       </div>
 
       <!-- SOLDES (Phase 3) -->
@@ -996,7 +951,6 @@ function nav(page) {
   event.target.classList.add('active');
   if (page === 'dashboard') loadDashboard();
   if (page === 'clients')   loadClients();
-  if (page === 'demandes')  loadDemandes();
   if (page === 'balances')  loadBalances();
   if (page === 'contracts') loadContracts();
   if (page === 'invoices')  loadInvoices();
@@ -4054,171 +4008,6 @@ async function saveNetwork() {
   toast('Réseau créé', 'success');
   closeModal('modal-network');
   loadNetworks();
-}
-
-// ═══════════════════════════════════════════════════════════
-//  DEMANDES (candidatures locataires)
-// ═══════════════════════════════════════════════════════════
-// Liste les candidatures issues de la page publique /postuler/
-// (table public.candidatures, alimentee par l'Edge Function
-// submit-candidature). Permet a l'admin Modulimo d'approuver ou
-// de refuser une demande directement depuis l'onglet Demandes.
-// Par defaut, le filtre statut affiche "ouvertes" = recu +
-// en_evaluation, ce qui correspond aux dossiers a traiter pour
-// Pointe Est et tout autre immeuble du reseau.
-let demandesCache = [];
-let demandesBuildings = [];
-
-async function loadDemandes() {
-  const tbody = document.getElementById('demandes-tbody');
-  tbody.innerHTML = '<tr><td colspan="9" style="text-align:center;color:var(--text3)">Chargement…</td></tr>';
-
-  const [candRes, buildRes] = await Promise.all([
-    sb.from('candidatures')
-      .select('id,created_at,building_id,status,form_data,applicant_email,applicant_name,target_rent,annual_income,score_total,score_category,reviewed_at,decision_at,destroyed_at')
-      .is('destroyed_at', null)
-      .order('created_at', { ascending: false }),
-    sb.from('building_registry').select('id,name,status')
-  ]);
-
-  if (candRes.error) { toast('Erreur chargement demandes: ' + candRes.error.message, 'error'); tbody.innerHTML = ''; return; }
-  demandesCache = candRes.data || [];
-  demandesBuildings = buildRes.data || [];
-
-  // Filtre immeubles : on liste tous les immeubles connus, plus
-  // ceux qui ont au moins une candidature (defensif si une candidature
-  // est rattachee a un building_id absent du registry).
-  const sel = document.getElementById('demandes-building-filter');
-  const current = sel.value;
-  const known = new Map(demandesBuildings.map(b => [b.id, b.name]));
-  demandesCache.forEach(c => { if (c.building_id && !known.has(c.building_id)) known.set(c.building_id, c.building_id.slice(0,8) + '…'); });
-  const opts = ['<option value="">Tous les immeubles</option>'];
-  // Pointe Est est notre 1er projet : on le met en tete s'il existe.
-  const sorted = [...known.entries()].sort((a, b) => {
-    const ap = /pointe/i.test(a[1]) ? 0 : 1;
-    const bp = /pointe/i.test(b[1]) ? 0 : 1;
-    if (ap !== bp) return ap - bp;
-    return a[1].localeCompare(b[1]);
-  });
-  sorted.forEach(([id, name]) => opts.push(`<option value="${id}">${escapeHtml(name)}</option>`));
-  sel.innerHTML = opts.join('');
-  sel.value = current || sorted.find(([, n]) => /pointe/i.test(n))?.[0] || '';
-
-  renderDemandes();
-}
-
-function renderDemandes() {
-  const tbody = document.getElementById('demandes-tbody');
-  const sumEl = document.getElementById('demandes-summary');
-  const buildingFilter = document.getElementById('demandes-building-filter').value;
-  const statusFilter = document.getElementById('demandes-status-filter').value;
-
-  const rows = demandesCache.filter(c => {
-    if (buildingFilter && c.building_id !== buildingFilter) return false;
-    if (statusFilter === 'ouvertes') return c.status === 'recu' || c.status === 'en_evaluation';
-    if (statusFilter && c.status !== statusFilter) return false;
-    return true;
-  });
-
-  if (!rows.length) {
-    tbody.innerHTML = '<tr><td colspan="9" style="text-align:center;color:var(--text3);padding:24px;">Aucune demande</td></tr>';
-    sumEl.textContent = '0 demande';
-    return;
-  }
-
-  const buildingName = id => demandesBuildings.find(b => b.id === id)?.name || (id ? '—' : 'Non précisé');
-  tbody.innerHTML = rows.map(c => {
-    const fd = c.form_data || {};
-    const phone = fd.phone ? `<br><span style="font-size:11px;color:var(--text3);">${escapeHtml(fd.phone)}</span>` : '';
-    const score = c.score_total != null
-      ? `<span class="badge ${_scoreBadgeClass(c.score_category)}">${c.score_total}/100${c.score_category ? ' · ' + _scoreLabel(c.score_category) : ''}</span>`
-      : '<span style="color:var(--text3)">—</span>';
-    const isOpen = c.status === 'recu' || c.status === 'en_evaluation';
-    const actions = isOpen
-      ? `<button class="btn btn-success btn-sm" onclick="approveDemande('${c.id}')">✓ Approuver</button>
-         <button class="btn btn-danger btn-sm" onclick="rejectDemande('${c.id}')">✕ Refuser</button>`
-      : `<span style="font-size:11px;color:var(--text3);">${c.decision_at ? 'Décidée le ' + new Date(c.decision_at).toLocaleDateString('fr-CA') : '—'}</span>`;
-    return `<tr>
-      <td><strong>${escapeHtml((c.applicant_name || '').trim() || '—')}</strong>${phone}</td>
-      <td style="font-size:12px;">${escapeHtml(c.applicant_email || '—')}</td>
-      <td>${escapeHtml(buildingName(c.building_id))}</td>
-      <td style="text-align:right;font-variant-numeric:tabular-nums;">${c.target_rent != null ? Number(c.target_rent).toFixed(0) + ' $' : '—'}</td>
-      <td style="text-align:right;font-variant-numeric:tabular-nums;">${c.annual_income ? Number(c.annual_income).toLocaleString('fr-CA') + ' $' : '—'}</td>
-      <td>${score}</td>
-      <td>${_demandeStatusBadge(c.status)}</td>
-      <td style="font-size:12px;">${new Date(c.created_at).toLocaleDateString('fr-CA')}</td>
-      <td><div class="td-actions">${actions}</div></td>
-    </tr>`;
-  }).join('');
-
-  const open = rows.filter(c => c.status === 'recu' || c.status === 'en_evaluation').length;
-  sumEl.textContent = `${rows.length} demande${rows.length > 1 ? 's' : ''} affichée${rows.length > 1 ? 's' : ''} · ${open} à traiter`;
-}
-
-function _scoreBadgeClass(cat) {
-  if (cat === 'excellent' || cat === 'bon') return 'badge-green';
-  if (cat === 'a_evaluer') return 'badge-yellow';
-  if (cat === 'a_risque') return 'badge-red';
-  return 'badge-gray';
-}
-function _scoreLabel(cat) {
-  return { excellent: 'Excellent', bon: 'Bon', a_evaluer: 'À évaluer', a_risque: 'À risque' }[cat] || cat;
-}
-function _demandeStatusBadge(status) {
-  const map = {
-    recu:          ['badge-yellow', 'Reçue'],
-    en_evaluation: ['badge-yellow', 'En évaluation'],
-    accepte:       ['badge-green',  'Acceptée'],
-    refuse:        ['badge-red',    'Refusée'],
-    retire:        ['badge-gray',   'Retirée'],
-    expire:        ['badge-gray',   'Expirée']
-  };
-  const [cls, lbl] = map[status] || ['badge-gray', status || '—'];
-  return `<span class="badge ${cls}">${lbl}</span>`;
-}
-
-async function approveDemande(id) {
-  const c = demandesCache.find(x => x.id === id);
-  if (!c) { toast('Demande introuvable', 'error'); return; }
-  const who = (c.applicant_name || '').trim() || c.applicant_email || 'ce candidat';
-  if (!confirm('Approuver la demande de ' + who + ' ?')) return;
-  const now = new Date().toISOString();
-  const { error } = await sb.from('candidatures').update({
-    status: 'accepte',
-    reviewed_by: currentAdmin?.id || null,
-    reviewed_at: now,
-    decision_at: now
-  }).eq('id', id);
-  if (error) { toast('Erreur: ' + error.message, 'error'); return; }
-  toast('Demande approuvée ✓', 'success');
-  loadDemandes();
-}
-
-async function rejectDemande(id) {
-  const c = demandesCache.find(x => x.id === id);
-  if (!c) { toast('Demande introuvable', 'error'); return; }
-  const who = (c.applicant_name || '').trim() || c.applicant_email || 'ce candidat';
-  if (!confirm('Refuser la demande de ' + who + ' ?')) return;
-  const now = new Date().toISOString();
-  // retention_until = 12 mois apres refus (Loi 25)
-  const retention = new Date();
-  retention.setMonth(retention.getMonth() + 12);
-  const { error } = await sb.from('candidatures').update({
-    status: 'refuse',
-    reviewed_by: currentAdmin?.id || null,
-    reviewed_at: now,
-    decision_at: now,
-    retention_until: retention.toISOString()
-  }).eq('id', id);
-  if (error) { toast('Erreur: ' + error.message, 'error'); return; }
-  toast('Demande refusée', 'success');
-  loadDemandes();
-}
-
-function escapeHtml(s) {
-  return String(s ?? '').replace(/[&<>"']/g, ch => ({
-    '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;'
-  }[ch]));
 }
 
 // HELPERS

--- a/index.html
+++ b/index.html
@@ -138,6 +138,7 @@
     <div class="sidebar">
       <div class="nav-item active" onclick="nav('dashboard')">📊 Tableau de bord</div>
       <div class="nav-item" onclick="nav('clients')">🏢 Clients</div>
+      <div class="nav-item" onclick="nav('demandes')">📋 Demandes</div>
       <div class="nav-item" onclick="nav('balances')">💳 Soldes</div>
       <div class="nav-item" onclick="nav('contracts')">📄 Contrats</div>
       <div class="nav-item" onclick="nav('invoices')">🧾 Factures</div>
@@ -186,6 +187,50 @@
             <tbody id="clients-tbody"></tbody>
           </table>
         </div>
+      </div>
+
+      <!-- DEMANDES (Candidatures locataires) -->
+      <div id="page-demandes" class="page">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;gap:10px;flex-wrap:wrap;">
+          <div class="page-title" style="margin:0">Demandes de location</div>
+          <div style="display:flex;gap:10px;align-items:center;">
+            <select id="demandes-building-filter" onchange="renderDemandes()" style="padding:8px 12px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;font-size:13px;">
+              <option value="">Tous les immeubles</option>
+            </select>
+            <select id="demandes-status-filter" onchange="renderDemandes()" style="padding:8px 12px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;font-size:13px;">
+              <option value="ouvertes" selected>À traiter</option>
+              <option value="">Toutes</option>
+              <option value="recu">Reçues</option>
+              <option value="en_evaluation">En évaluation</option>
+              <option value="accepte">Acceptées</option>
+              <option value="refuse">Refusées</option>
+              <option value="retire">Retirées</option>
+              <option value="expire">Expirées</option>
+            </select>
+            <button class="btn btn-secondary btn-sm" onclick="loadDemandes()">↻ Rafraîchir</button>
+          </div>
+        </div>
+        <div class="card" style="padding:0">
+          <table>
+            <thead>
+              <tr>
+                <th>Candidat</th>
+                <th>Courriel</th>
+                <th>Immeuble</th>
+                <th style="text-align:right">Loyer cible</th>
+                <th style="text-align:right">Revenu annuel</th>
+                <th>Score</th>
+                <th>Statut</th>
+                <th>Reçue le</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody id="demandes-tbody">
+              <tr><td colspan="9" style="text-align:center;color:var(--text3)">Chargement…</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div id="demandes-summary" style="margin-top:16px;font-size:13px;color:var(--text2);"></div>
       </div>
 
       <!-- SOLDES (Phase 3) -->
@@ -951,6 +996,7 @@ function nav(page) {
   event.target.classList.add('active');
   if (page === 'dashboard') loadDashboard();
   if (page === 'clients')   loadClients();
+  if (page === 'demandes')  loadDemandes();
   if (page === 'balances')  loadBalances();
   if (page === 'contracts') loadContracts();
   if (page === 'invoices')  loadInvoices();
@@ -4008,6 +4054,171 @@ async function saveNetwork() {
   toast('Réseau créé', 'success');
   closeModal('modal-network');
   loadNetworks();
+}
+
+// ═══════════════════════════════════════════════════════════
+//  DEMANDES (candidatures locataires)
+// ═══════════════════════════════════════════════════════════
+// Liste les candidatures issues de la page publique /postuler/
+// (table public.candidatures, alimentee par l'Edge Function
+// submit-candidature). Permet a l'admin Modulimo d'approuver ou
+// de refuser une demande directement depuis l'onglet Demandes.
+// Par defaut, le filtre statut affiche "ouvertes" = recu +
+// en_evaluation, ce qui correspond aux dossiers a traiter pour
+// Pointe Est et tout autre immeuble du reseau.
+let demandesCache = [];
+let demandesBuildings = [];
+
+async function loadDemandes() {
+  const tbody = document.getElementById('demandes-tbody');
+  tbody.innerHTML = '<tr><td colspan="9" style="text-align:center;color:var(--text3)">Chargement…</td></tr>';
+
+  const [candRes, buildRes] = await Promise.all([
+    sb.from('candidatures')
+      .select('id,created_at,building_id,status,form_data,applicant_email,applicant_name,target_rent,annual_income,score_total,score_category,reviewed_at,decision_at,destroyed_at')
+      .is('destroyed_at', null)
+      .order('created_at', { ascending: false }),
+    sb.from('building_registry').select('id,name,status')
+  ]);
+
+  if (candRes.error) { toast('Erreur chargement demandes: ' + candRes.error.message, 'error'); tbody.innerHTML = ''; return; }
+  demandesCache = candRes.data || [];
+  demandesBuildings = buildRes.data || [];
+
+  // Filtre immeubles : on liste tous les immeubles connus, plus
+  // ceux qui ont au moins une candidature (defensif si une candidature
+  // est rattachee a un building_id absent du registry).
+  const sel = document.getElementById('demandes-building-filter');
+  const current = sel.value;
+  const known = new Map(demandesBuildings.map(b => [b.id, b.name]));
+  demandesCache.forEach(c => { if (c.building_id && !known.has(c.building_id)) known.set(c.building_id, c.building_id.slice(0,8) + '…'); });
+  const opts = ['<option value="">Tous les immeubles</option>'];
+  // Pointe Est est notre 1er projet : on le met en tete s'il existe.
+  const sorted = [...known.entries()].sort((a, b) => {
+    const ap = /pointe/i.test(a[1]) ? 0 : 1;
+    const bp = /pointe/i.test(b[1]) ? 0 : 1;
+    if (ap !== bp) return ap - bp;
+    return a[1].localeCompare(b[1]);
+  });
+  sorted.forEach(([id, name]) => opts.push(`<option value="${id}">${escapeHtml(name)}</option>`));
+  sel.innerHTML = opts.join('');
+  sel.value = current || sorted.find(([, n]) => /pointe/i.test(n))?.[0] || '';
+
+  renderDemandes();
+}
+
+function renderDemandes() {
+  const tbody = document.getElementById('demandes-tbody');
+  const sumEl = document.getElementById('demandes-summary');
+  const buildingFilter = document.getElementById('demandes-building-filter').value;
+  const statusFilter = document.getElementById('demandes-status-filter').value;
+
+  const rows = demandesCache.filter(c => {
+    if (buildingFilter && c.building_id !== buildingFilter) return false;
+    if (statusFilter === 'ouvertes') return c.status === 'recu' || c.status === 'en_evaluation';
+    if (statusFilter && c.status !== statusFilter) return false;
+    return true;
+  });
+
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="9" style="text-align:center;color:var(--text3);padding:24px;">Aucune demande</td></tr>';
+    sumEl.textContent = '0 demande';
+    return;
+  }
+
+  const buildingName = id => demandesBuildings.find(b => b.id === id)?.name || (id ? '—' : 'Non précisé');
+  tbody.innerHTML = rows.map(c => {
+    const fd = c.form_data || {};
+    const phone = fd.phone ? `<br><span style="font-size:11px;color:var(--text3);">${escapeHtml(fd.phone)}</span>` : '';
+    const score = c.score_total != null
+      ? `<span class="badge ${_scoreBadgeClass(c.score_category)}">${c.score_total}/100${c.score_category ? ' · ' + _scoreLabel(c.score_category) : ''}</span>`
+      : '<span style="color:var(--text3)">—</span>';
+    const isOpen = c.status === 'recu' || c.status === 'en_evaluation';
+    const actions = isOpen
+      ? `<button class="btn btn-success btn-sm" onclick="approveDemande('${c.id}')">✓ Approuver</button>
+         <button class="btn btn-danger btn-sm" onclick="rejectDemande('${c.id}')">✕ Refuser</button>`
+      : `<span style="font-size:11px;color:var(--text3);">${c.decision_at ? 'Décidée le ' + new Date(c.decision_at).toLocaleDateString('fr-CA') : '—'}</span>`;
+    return `<tr>
+      <td><strong>${escapeHtml((c.applicant_name || '').trim() || '—')}</strong>${phone}</td>
+      <td style="font-size:12px;">${escapeHtml(c.applicant_email || '—')}</td>
+      <td>${escapeHtml(buildingName(c.building_id))}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums;">${c.target_rent != null ? Number(c.target_rent).toFixed(0) + ' $' : '—'}</td>
+      <td style="text-align:right;font-variant-numeric:tabular-nums;">${c.annual_income ? Number(c.annual_income).toLocaleString('fr-CA') + ' $' : '—'}</td>
+      <td>${score}</td>
+      <td>${_demandeStatusBadge(c.status)}</td>
+      <td style="font-size:12px;">${new Date(c.created_at).toLocaleDateString('fr-CA')}</td>
+      <td><div class="td-actions">${actions}</div></td>
+    </tr>`;
+  }).join('');
+
+  const open = rows.filter(c => c.status === 'recu' || c.status === 'en_evaluation').length;
+  sumEl.textContent = `${rows.length} demande${rows.length > 1 ? 's' : ''} affichée${rows.length > 1 ? 's' : ''} · ${open} à traiter`;
+}
+
+function _scoreBadgeClass(cat) {
+  if (cat === 'excellent' || cat === 'bon') return 'badge-green';
+  if (cat === 'a_evaluer') return 'badge-yellow';
+  if (cat === 'a_risque') return 'badge-red';
+  return 'badge-gray';
+}
+function _scoreLabel(cat) {
+  return { excellent: 'Excellent', bon: 'Bon', a_evaluer: 'À évaluer', a_risque: 'À risque' }[cat] || cat;
+}
+function _demandeStatusBadge(status) {
+  const map = {
+    recu:          ['badge-yellow', 'Reçue'],
+    en_evaluation: ['badge-yellow', 'En évaluation'],
+    accepte:       ['badge-green',  'Acceptée'],
+    refuse:        ['badge-red',    'Refusée'],
+    retire:        ['badge-gray',   'Retirée'],
+    expire:        ['badge-gray',   'Expirée']
+  };
+  const [cls, lbl] = map[status] || ['badge-gray', status || '—'];
+  return `<span class="badge ${cls}">${lbl}</span>`;
+}
+
+async function approveDemande(id) {
+  const c = demandesCache.find(x => x.id === id);
+  if (!c) { toast('Demande introuvable', 'error'); return; }
+  const who = (c.applicant_name || '').trim() || c.applicant_email || 'ce candidat';
+  if (!confirm('Approuver la demande de ' + who + ' ?')) return;
+  const now = new Date().toISOString();
+  const { error } = await sb.from('candidatures').update({
+    status: 'accepte',
+    reviewed_by: currentAdmin?.id || null,
+    reviewed_at: now,
+    decision_at: now
+  }).eq('id', id);
+  if (error) { toast('Erreur: ' + error.message, 'error'); return; }
+  toast('Demande approuvée ✓', 'success');
+  loadDemandes();
+}
+
+async function rejectDemande(id) {
+  const c = demandesCache.find(x => x.id === id);
+  if (!c) { toast('Demande introuvable', 'error'); return; }
+  const who = (c.applicant_name || '').trim() || c.applicant_email || 'ce candidat';
+  if (!confirm('Refuser la demande de ' + who + ' ?')) return;
+  const now = new Date().toISOString();
+  // retention_until = 12 mois apres refus (Loi 25)
+  const retention = new Date();
+  retention.setMonth(retention.getMonth() + 12);
+  const { error } = await sb.from('candidatures').update({
+    status: 'refuse',
+    reviewed_by: currentAdmin?.id || null,
+    reviewed_at: now,
+    decision_at: now,
+    retention_until: retention.toISOString()
+  }).eq('id', id);
+  if (error) { toast('Erreur: ' + error.message, 'error'); return; }
+  toast('Demande refusée', 'success');
+  loadDemandes();
+}
+
+function escapeHtml(s) {
+  return String(s ?? '').replace(/[&<>"']/g, ch => ({
+    '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;'
+  }[ch]));
 }
 
 // HELPERS

--- a/sql/024_candidatures_building_management.sql
+++ b/sql/024_candidatures_building_management.sql
@@ -1,0 +1,138 @@
+-- =====================================================================
+-- 024_candidatures_building_management.sql
+-- Permet a chaque CoHabitat (par immeuble) de lister et de decider
+-- les candidatures qui le concernent, sans exposer la table publique
+-- aux residents authentifies cote local.
+--
+-- Contexte :
+--   * 023_candidatures.sql a ete pose avec une RLS "alpha" :
+--     authenticated (= login modulimo-admin) peut tout voir / modifier.
+--   * Mais les admins CoHabitat n'ont PAS de session contre le projet
+--     central : leur auth vit dans le projet Supabase de l'immeuble.
+--     Ils utilisent l'anon_key central pour atteindre les RPC publiques
+--     (cf. CENTRAL_URL/CENTRAL_KEY dans CoHabitat/index.html).
+--   * Modulimo central ne doit PAS approuver les locataires d'un
+--     immeuble individuel : c'est l'admin du building qui le fait.
+--
+-- Ce que ce fichier ajoute :
+--   * list_candidatures_for_building(uuid) : retourne les candidatures
+--     non detruites pour un building donne (lecture). Expose a anon.
+--   * decide_candidature_for_building(uuid, text, uuid)
+--     : passe le statut a 'accepte' / 'refuse' / 'en_evaluation' pour
+--     une candidature donnee, en exigeant que le building_id de la
+--     candidature corresponde a celui passe en argument (= scoping
+--     par instance CoHabitat). Expose a anon.
+--
+-- Modele de confiance :
+--   * Chaque CoHabitat connait son propre building_id (system_settings).
+--   * La cle anon centrale est publique cote front mais le scoping par
+--     building_id empeche un immeuble d'agir sur les candidatures d'un
+--     autre. C'est le meme niveau de confiance que les autres RPC anon
+--     existantes du projet (create_resident_client, etc.).
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 1. Lecture : liste des candidatures d'un building
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.list_candidatures_for_building(
+  p_building_id uuid
+)
+RETURNS TABLE (
+  id              uuid,
+  created_at      timestamptz,
+  status          text,
+  applicant_email text,
+  applicant_name  text,
+  target_rent     numeric,
+  annual_income   numeric,
+  score_total     integer,
+  score_category  text,
+  form_data       jsonb,
+  reviewed_at     timestamptz,
+  decision_at     timestamptz
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    c.id, c.created_at, c.status,
+    c.applicant_email, c.applicant_name, c.target_rent, c.annual_income,
+    c.score_total, c.score_category, c.form_data,
+    c.reviewed_at, c.decision_at
+  FROM public.candidatures c
+  WHERE c.building_id = p_building_id
+    AND c.destroyed_at IS NULL
+  ORDER BY c.created_at DESC;
+$$;
+
+REVOKE ALL ON FUNCTION public.list_candidatures_for_building(uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.list_candidatures_for_building(uuid) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.list_candidatures_for_building(uuid) IS
+  'Liste les candidatures (non detruites) pour un building donne. Appelee depuis l''onglet Demandes du CoHabitat de chaque immeuble.';
+
+-- ---------------------------------------------------------------------
+-- 2. Decision : approuver / refuser / passer en evaluation
+-- ---------------------------------------------------------------------
+-- Le scoping par building_id (parametre + check) empeche un CoHabitat
+-- d'agir sur les candidatures d'un autre immeuble.
+-- Le retention_until est pose automatiquement a +12 mois pour 'refuse'
+-- (Loi 25 : conservation max apres refus).
+CREATE OR REPLACE FUNCTION public.decide_candidature_for_building(
+  p_candidature_id uuid,
+  p_decision       text,
+  p_building_id    uuid
+)
+RETURNS public.candidatures
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_row public.candidatures;
+BEGIN
+  IF p_decision NOT IN ('accepte','refuse','en_evaluation') THEN
+    RAISE EXCEPTION 'Decision invalide: % (attendu: accepte | refuse | en_evaluation)', p_decision
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  UPDATE public.candidatures c
+  SET
+    status          = p_decision,
+    reviewed_at     = now(),
+    decision_at     = CASE WHEN p_decision IN ('accepte','refuse') THEN now() ELSE c.decision_at END,
+    retention_until = CASE WHEN p_decision = 'refuse' THEN now() + interval '12 months' ELSE c.retention_until END
+  WHERE c.id = p_candidature_id
+    AND c.building_id = p_building_id
+    AND c.destroyed_at IS NULL
+  RETURNING c.* INTO v_row;
+
+  IF v_row.id IS NULL THEN
+    RAISE EXCEPTION 'Candidature introuvable ou hors scope (id=%, building=%)', p_candidature_id, p_building_id
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  RETURN v_row;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.decide_candidature_for_building(uuid, text, uuid) FROM public;
+GRANT EXECUTE ON FUNCTION public.decide_candidature_for_building(uuid, text, uuid) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.decide_candidature_for_building(uuid, text, uuid) IS
+  'Met a jour le statut d''une candidature, scope par building_id. Appelee depuis l''onglet Demandes du CoHabitat de chaque immeuble.';
+
+COMMIT;
+
+NOTIFY pgrst, 'reload schema';
+
+-- ---------------------------------------------------------------------
+-- Rollback (manuel si besoin)
+-- ---------------------------------------------------------------------
+-- BEGIN;
+-- DROP FUNCTION IF EXISTS public.decide_candidature_for_building(uuid, text, uuid);
+-- DROP FUNCTION IF EXISTS public.list_candidatures_for_building(uuid);
+-- COMMIT;


### PR DESCRIPTION
## Sommaire

Modulimo central **n'autorise pas** les locataires d'un immeuble individuel — c'est délégué à l'admin CoHabitat de chaque immeuble. Cette PR ajoute :

- Nouvel onglet **📊 Demandes (stats)** : KPIs réseau + tableau par immeuble + tableau par mois, alimenté par la vue `candidatures_analytics` (lecture seule, aucun bouton d'approbation)
- `sql/024_candidatures_building_management.sql` : RPC `list_candidatures_for_building(uuid)` et `decide_candidature_for_building(uuid, text, uuid)` (SECURITY DEFINER, scopées par `building_id`, exposées à `anon` / `authenticated`) — utilisées par CoHabitat per-building (PR jumelle https://github.com/simonvelucia-afk/CoHabitat/pull/36)

⚠️ La migration SQL 024 doit être appliquée sur le projet Supabase central (déjà fait).

## Test plan

- [ ] Hard refresh modulimo-admin
- [ ] Sidebar → **📊 Demandes (stats)**
- [ ] Vérifier les KPIs (Total / À traiter / Acceptées / Taux d'acceptation)
- [ ] Tableau "Par immeuble" : Pointe Est doit apparaître si au moins une candidature
- [ ] Tableau "Par mois" : 12 derniers mois

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrWjH1dBbkRmnqFjTNyQ5b)_