### PR TITLE
Add lead capture form for Pointe Est project

### DIFF
--- a/sql/025_leads_pointe_est.sql
+++ b/sql/025_leads_pointe_est.sql
@@ -1,0 +1,117 @@
+-- ============================================================
+-- 025_leads_pointe_est.sql
+-- Migration : table des leads Pointe Est (formulaire de contact
+-- de modulimo.com — repo modulimo-home, js/lead-form.js).
+-- Conforme Loi 25 (Québec)
+-- ============================================================
+-- À exécuter dans le SQL Editor du projet Central (bpxscgrbxjscicpnheep).
+-- Idempotent : peut être rejoué sans danger.
+-- Copie de référence : modulimo-home/supabase/leads_pointe_est.sql
+--
+-- RLS « option alpha » (pattern des migrations 013/023 de modulimo-admin) :
+-- pas de table user_roles dans ce projet — tout utilisateur authentifié
+-- (login modulimo-admin) est admin. La sécurité vient de qui peut se
+-- connecter au projet. Aucune policy INSERT : les leads entrent
+-- exclusivement par l'Edge Function submit-lead-pointe-est
+-- (service_role, bypass RLS).
+
+BEGIN;
+
+-- 1. Table principale
+create table if not exists public.leads_pointe_est (
+  id          uuid primary key default gen_random_uuid(),
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now(),
+
+  -- Identité et message (renseignements personnels — Loi 25)
+  first_name  text not null,
+  last_name   text not null,
+  email       text not null,
+  message     text,
+
+  -- Consentement explicite (récap horodaté, version du texte affiché)
+  consent     jsonb not null,
+
+  -- Suivi commercial
+  status      text not null default 'nouveau'
+    check (status in ('nouveau', 'contacte', 'converti', 'ferme')),
+  admin_notes text,
+
+  -- Métadonnées techniques (Loi 25 : hash de l'IP, jamais l'IP brute)
+  locale      text,
+  source_page text,
+  user_agent  text,
+  ip_hash     text,
+
+  -- Date de destruction effective des renseignements personnels
+  destroyed_at timestamptz
+);
+
+create index if not exists idx_leads_pe_created on public.leads_pointe_est(created_at desc);
+create index if not exists idx_leads_pe_status  on public.leads_pointe_est(status);
+create index if not exists idx_leads_pe_email   on public.leads_pointe_est(email);
+
+-- 2. Trigger updated_at (réutilise la convention set_updated_at de 023)
+create or replace function public.set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_leads_pe_updated on public.leads_pointe_est;
+create trigger trg_leads_pe_updated
+  before update on public.leads_pointe_est
+  for each row execute function public.set_updated_at();
+
+-- 3. RLS — option alpha (authenticated = admin)
+alter table public.leads_pointe_est enable row level security;
+
+-- INSERT : aucune policy — Edge Function uniquement (service_role).
+
+drop policy if exists leads_pe_authenticated_select on public.leads_pointe_est;
+create policy leads_pe_authenticated_select on public.leads_pointe_est
+  for select to authenticated using (true);
+
+drop policy if exists leads_pe_authenticated_update on public.leads_pointe_est;
+create policy leads_pe_authenticated_update on public.leads_pointe_est
+  for update to authenticated using (true) with check (true);
+
+drop policy if exists leads_pe_authenticated_delete on public.leads_pointe_est;
+create policy leads_pe_authenticated_delete on public.leads_pointe_est
+  for delete to authenticated using (true);
+
+grant select, update, delete on public.leads_pointe_est to authenticated;
+
+-- 4. Destruction des renseignements personnels (droit de retrait — Loi 25)
+-- SECURITY DEFINER pour bypasser RLS, garde-fou minimal auth.uid()
+-- (modèle authenticated = admin, comme destroy_candidature_pii).
+create or replace function public.destroy_lead_pointe_est_pii(p_lead_id uuid)
+returns void language plpgsql security definer set search_path = public as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Authentication required' using errcode = 'insufficient_privilege';
+  end if;
+
+  update public.leads_pointe_est
+  set
+    first_name   = '[détruit]',
+    last_name    = '[détruit]',
+    email        = '[détruit]',
+    message      = null,
+    consent      = jsonb_build_object('_destroyed', true),
+    user_agent   = null,
+    ip_hash      = null,
+    destroyed_at = now()
+  where id = p_lead_id;
+end;
+$$;
+
+revoke all on function public.destroy_lead_pointe_est_pii(uuid) from public;
+grant execute on function public.destroy_lead_pointe_est_pii(uuid) to authenticated;
+
+comment on table public.leads_pointe_est is
+  'Leads du formulaire de contact Pointe Est (modulimo.com). Conforme Loi 25 : consentement explicite horodaté, IP hashée, fonction de destruction des PII. Insertion via Edge Function submit-lead-pointe-est uniquement.';
+
+COMMIT;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -34,3 +34,12 @@ verify_jwt = false
 # key (deja publiques) sont utilisees par le frontend.
 [functions.submit-candidature]
 verify_jwt = false
+
+# submit-lead-pointe-est : formulaire de capture de leads public sur
+# modulimo.com (accueil, /projets, /projets/pointe-est). Meme modele
+# que submit-candidature : validation + honeypot cote fonction,
+# insertion via service_role dans leads_pointe_est (migration 025),
+# notification courriel via Resend (secrets RESEND_KEY / RESEND_FROM,
+# destinataire optionnel LEADS_NOTIFY_TO).
+[functions.submit-lead-pointe-est]
+verify_jwt = false

--- a/supabase/functions/submit-lead-pointe-est/index.ts
+++ b/supabase/functions/submit-lead-pointe-est/index.ts
@@ -1,0 +1,147 @@
+// ============================================================
+// MODULIMO — Edge Function : submit-lead-pointe-est
+// ============================================================
+// Reçoit le formulaire « Informez-vous » du site modulimo.com :
+//   1. insère le lead dans la table public.leads_pointe_est
+//   2. envoie une notification courriel via Resend
+//
+// Secrets requis (déjà configurés côté Supabase pour send-email) :
+//   RESEND_KEY        — clé API Resend (ne JAMAIS la mettre dans le repo)
+//   RESEND_FROM       — ex. 'Modulimo <no-reply@modulimo.com>' (optionnel)
+//   LEADS_NOTIFY_TO   — destinataire des notifications
+//                       (optionnel, défaut : contribution@modulimo.com)
+//
+// Déploiement (projet Central) :
+//   supabase functions deploy submit-lead-pointe-est --project-ref bpxscgrbxjscicpnheep
+// ============================================================
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const RESEND_KEY = Deno.env.get("RESEND_KEY") ?? "";
+const RESEND_FROM = Deno.env.get("RESEND_FROM") ?? "Modulimo <no-reply@modulimo.com>";
+const NOTIFY_TO = Deno.env.get("LEADS_NOTIFY_TO") ?? "contribution@modulimo.com";
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "authorization, content-type, apikey, x-client-info",
+  "Access-Control-Max-Age": "86400",
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, "content-type": "application/json" },
+  });
+}
+
+function esc(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  }[c] as string));
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: CORS_HEADERS });
+  if (req.method !== "POST") return json({ error: "Method not allowed" }, 405);
+
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "Corps JSON invalide" }, 400);
+  }
+
+  // Honeypot anti-spam : si le champ caché est rempli, on répond
+  // « succès » sans rien enregistrer (ne pas renseigner les bots).
+  if (typeof body.website === "string" && body.website.trim() !== "") {
+    return json({ ok: true });
+  }
+
+  const firstName = String(body.first_name ?? "").trim().slice(0, 120);
+  const lastName = String(body.last_name ?? "").trim().slice(0, 120);
+  const email = String(body.email ?? "").trim().slice(0, 254);
+  const message = String(body.message ?? "").trim().slice(0, 4000);
+  const locale = String(body.locale ?? "").trim().slice(0, 16) || null;
+  const sourcePage = String(body.source_page ?? "").trim().slice(0, 200) || null;
+
+  if (!firstName || !lastName) return json({ error: "missing_name" }, 400);
+  if (!EMAIL_RE.test(email)) return json({ error: "invalid_email" }, 400);
+  if (body.consent !== true) return json({ error: "missing_consent" }, 400);
+
+  // Loi 25 : hash de l'IP, jamais l'IP brute
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0].trim() ?? "";
+  let ipHash: string | null = null;
+  if (ip) {
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(ip));
+    ipHash = Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
+    auth: { persistSession: false },
+  });
+
+  const { data, error } = await supabase
+    .from("leads_pointe_est")
+    .insert({
+      first_name: firstName,
+      last_name: lastName,
+      email,
+      message: message || null,
+      consent: {
+        marketing_contact: true,
+        text_version: body.consent_text_version ?? "2026-06-v1",
+        consented_at: new Date().toISOString(),
+      },
+      locale,
+      source_page: sourcePage,
+      user_agent: String(body.user_agent ?? "").slice(0, 500) || null,
+      ip_hash: ipHash,
+      status: "nouveau",
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    console.error("[submit-lead-pointe-est] insert error:", error);
+    return json({ error: "storage_error" }, 500);
+  }
+
+  // Notification courriel — un échec d'envoi ne doit pas faire échouer
+  // la requête : le lead est déjà enregistré.
+  if (RESEND_KEY) {
+    try {
+      const res = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${RESEND_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: RESEND_FROM,
+          to: [NOTIFY_TO],
+          reply_to: email,
+          subject: `Nouveau lead Pointe Est — ${firstName} ${lastName}`,
+          html: [
+            `<h2>Nouveau lead — Pointe Est</h2>`,
+            `<p><strong>Nom :</strong> ${esc(firstName)} ${esc(lastName)}</p>`,
+            `<p><strong>Courriel :</strong> ${esc(email)}</p>`,
+            message ? `<p><strong>Message :</strong><br>${esc(message).replace(/\n/g, "<br>")}</p>` : "",
+            `<p style="color:#888;font-size:12px">Langue : ${esc(locale ?? "—")} · Page : ${esc(sourcePage ?? "—")} · ID : ${data.id}</p>`,
+          ].join("\n"),
+        }),
+      });
+      if (!res.ok) console.error("[submit-lead-pointe-est] resend error:", res.status, await res.text());
+    } catch (e) {
+      console.error("[submit-lead-pointe-est] resend exception:", e);
+    }
+  } else {
+    console.warn("[submit-lead-pointe-est] RESEND_KEY absent — notification non envoyée");
+  }
+
+  return json({ ok: true, lead_id: data.id });
+});


### PR DESCRIPTION
## Summary
Adds a complete lead capture system for the Pointe Est project, including a new Edge Function to handle form submissions, a database migration to store leads, and configuration updates.

## Key Changes

- **New Edge Function** (`submit-lead-pointe-est`): Handles form submissions from modulimo.com with:
  - Honeypot anti-spam protection
  - Input validation (name, email, consent)
  - GDPR/Loi 25 compliance: IP hashing instead of storing raw IPs
  - Lead insertion into `leads_pointe_est` table via service role
  - Email notifications via Resend API (non-blocking)
  - CORS support for public form submissions

- **Database Migration** (`025_leads_pointe_est.sql`): Creates the `leads_pointe_est` table with:
  - Core fields: first_name, last_name, email, message
  - Consent tracking with versioned consent text and timestamp
  - Status workflow (nouveau → contacte → converti → ferme)
  - Metadata: locale, source_page, user_agent, ip_hash
  - Automatic `updated_at` trigger
  - Row-level security: authenticated users can SELECT/UPDATE/DELETE, but INSERT only via Edge Function
  - `destroy_lead_pointe_est_pii()` function for GDPR right-to-be-forgotten compliance

- **Configuration**: Updated `supabase/config.toml` to register the new function with `verify_jwt = false` (public endpoint)

## Implementation Details

- Email validation uses regex pattern: `/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/`
- HTML escaping function prevents XSS in email notifications
- IP hashing uses SHA-256 for privacy compliance
- Resend email failures don't block the lead insertion (graceful degradation)
- Honeypot field (`website`) silently succeeds without storing data to avoid bot reconnaissance
- All personal data fields are truncated to reasonable limits (120-4000 chars)

https://claude.ai/code/session_018d3rY5XDvBxTN8MH4vqyRL